### PR TITLE
Bugfix: initial state is not handled

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
@@ -88,6 +88,9 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
         Path daemonJarPath = config.basedir().resolve(daemonConfig.daemonJarName());
         if (!Files.exists(daemonJarPath)) {
             try {
+                if (!Files.isDirectory(daemonJarPath.getParent())) {
+                    Files.createDirectories(daemonJarPath.getParent());
+                }
                 logger.info(
                         "Resolving Mimir daemon version {}",
                         config.mimirVersion().orElseThrow());


### PR DESCRIPTION
We try to resolve daemon into ~/.mimir/damon-... but what if ~/.mimir directory does not exists yet?