### PR TITLE
Ability to pass on mimir.basedir

### DIFF
--- a/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonConfig.java
+++ b/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonConfig.java
@@ -35,6 +35,7 @@ public class DaemonConfig {
         String daemonLogName = "daemon-" + mimirVersion + ".log";
         String daemonGav = "eu.maveniverse.maven.mimir:daemon:jar:daemon:" + mimirVersion;
         String systemNode = "file";
+        boolean passOnUserHome = false;
 
         if (config.effectiveProperties().containsKey("mimir.daemon.socketPath")) {
             socketPath =
@@ -61,6 +62,9 @@ public class DaemonConfig {
         if (config.effectiveProperties().containsKey("mimir.daemon.systemNode")) {
             systemNode = config.effectiveProperties().get("mimir.daemon.systemNode");
         }
+        if (config.effectiveProperties().containsKey("mimir.daemon.passOnUserHome")) {
+            passOnUserHome = Boolean.parseBoolean(config.effectiveProperties().get("mimir.daemon.passOnUserHome"));
+        }
         return new DaemonConfig(
                 socketPath,
                 daemonJavaHome,
@@ -70,7 +74,8 @@ public class DaemonConfig {
                 daemonJarName,
                 daemonLogName,
                 daemonGav,
-                systemNode);
+                systemNode,
+                passOnUserHome);
     }
 
     public static final String NAME = "daemon";
@@ -84,6 +89,7 @@ public class DaemonConfig {
     private final String daemonLogName;
     private final String daemonGav;
     private final String systemNode;
+    private final boolean passOnUserHome;
 
     private DaemonConfig(
             Path socketPath,
@@ -94,7 +100,8 @@ public class DaemonConfig {
             String daemonJarName,
             String daemonLogName,
             String daemonGav,
-            String systemNode) {
+            String systemNode,
+            boolean passOnUserHome) {
         this.socketPath = socketPath;
         this.daemonJavaHome = daemonJavaHome;
         this.autoupdate = autoupdate;
@@ -104,6 +111,7 @@ public class DaemonConfig {
         this.daemonLogName = daemonLogName;
         this.daemonGav = daemonGav;
         this.systemNode = systemNode;
+        this.passOnUserHome = passOnUserHome;
     }
 
     public Path socketPath() {
@@ -140,5 +148,9 @@ public class DaemonConfig {
 
     public String systemNode() {
         return systemNode;
+    }
+
+    public boolean passOnUserHome() {
+        return passOnUserHome;
     }
 }

--- a/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonConfig.java
+++ b/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonConfig.java
@@ -35,7 +35,7 @@ public class DaemonConfig {
         String daemonLogName = "daemon-" + mimirVersion + ".log";
         String daemonGav = "eu.maveniverse.maven.mimir:daemon:jar:daemon:" + mimirVersion;
         String systemNode = "file";
-        boolean passOnUserHome = false;
+        boolean passOnBasedir = false;
 
         if (config.effectiveProperties().containsKey("mimir.daemon.socketPath")) {
             socketPath =
@@ -62,8 +62,8 @@ public class DaemonConfig {
         if (config.effectiveProperties().containsKey("mimir.daemon.systemNode")) {
             systemNode = config.effectiveProperties().get("mimir.daemon.systemNode");
         }
-        if (config.effectiveProperties().containsKey("mimir.daemon.passOnUserHome")) {
-            passOnUserHome = Boolean.parseBoolean(config.effectiveProperties().get("mimir.daemon.passOnUserHome"));
+        if (config.effectiveProperties().containsKey("mimir.daemon.passOnBasedir")) {
+            passOnBasedir = Boolean.parseBoolean(config.effectiveProperties().get("mimir.daemon.passOnBasedir"));
         }
         return new DaemonConfig(
                 socketPath,
@@ -75,7 +75,7 @@ public class DaemonConfig {
                 daemonLogName,
                 daemonGav,
                 systemNode,
-                passOnUserHome);
+                passOnBasedir);
     }
 
     public static final String NAME = "daemon";
@@ -89,7 +89,7 @@ public class DaemonConfig {
     private final String daemonLogName;
     private final String daemonGav;
     private final String systemNode;
-    private final boolean passOnUserHome;
+    private final boolean passOnBasedir;
 
     private DaemonConfig(
             Path socketPath,
@@ -101,7 +101,7 @@ public class DaemonConfig {
             String daemonLogName,
             String daemonGav,
             String systemNode,
-            boolean passOnUserHome) {
+            boolean passOnBasedir) {
         this.socketPath = socketPath;
         this.daemonJavaHome = daemonJavaHome;
         this.autoupdate = autoupdate;
@@ -111,7 +111,7 @@ public class DaemonConfig {
         this.daemonLogName = daemonLogName;
         this.daemonGav = daemonGav;
         this.systemNode = systemNode;
-        this.passOnUserHome = passOnUserHome;
+        this.passOnBasedir = passOnBasedir;
     }
 
     public Path socketPath() {
@@ -150,7 +150,7 @@ public class DaemonConfig {
         return systemNode;
     }
 
-    public boolean passOnUserHome() {
-        return passOnUserHome;
+    public boolean passOnBasedir() {
+        return passOnBasedir;
     }
 }

--- a/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonNodeFactory.java
+++ b/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonNodeFactory.java
@@ -71,9 +71,7 @@ public class DaemonNodeFactory implements LocalNodeFactory {
                                     ? "java.exe"
                                     : "java")
                     .toString();
-            ProcessBuilder pb = new ProcessBuilder()
-                    .directory(basedir.toFile())
-                    .redirectOutput(daemonLog.toFile());
+            ProcessBuilder pb = new ProcessBuilder().directory(basedir.toFile()).redirectOutput(daemonLog.toFile());
 
             ArrayList<String> command = new ArrayList<>();
             command.add(java);

--- a/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonNodeFactory.java
+++ b/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonNodeFactory.java
@@ -75,8 +75,8 @@ public class DaemonNodeFactory implements LocalNodeFactory {
 
             ArrayList<String> command = new ArrayList<>();
             command.add(java);
-            if (daemonConfig.passOnUserHome()) {
-                command.add("-Duser.home=" + System.getProperty("user.home"));
+            if (daemonConfig.passOnBasedir()) {
+                command.add("-Dmimir.basedir=" + basedir);
             }
             command.add("-jar");
             command.add(daemonJarName);

--- a/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonNodeFactory.java
+++ b/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonNodeFactory.java
@@ -14,6 +14,7 @@ import eu.maveniverse.maven.mimir.shared.node.LocalNodeFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Inject;
@@ -72,8 +73,17 @@ public class DaemonNodeFactory implements LocalNodeFactory {
                     .toString();
             ProcessBuilder pb = new ProcessBuilder()
                     .directory(basedir.toFile())
-                    .redirectOutput(daemonLog.toFile())
-                    .command(java, "-jar", daemonJarName);
+                    .redirectOutput(daemonLog.toFile());
+
+            ArrayList<String> command = new ArrayList<>();
+            command.add(java);
+            if (daemonConfig.passOnUserHome()) {
+                command.add("-Duser.home=" + System.getProperty("user.home"));
+            }
+            command.add("-jar");
+            command.add(daemonJarName);
+
+            pb.command(command);
             Process p = pb.start();
             try {
                 while (p.isAlive() && !Files.exists(daemonConfig.socketPath())) {


### PR DESCRIPTION
In some cases, like embedded IT it is useful to make daemon run in same "chroot" as IT itself with
altered user home/basedir.