### PR TITLE
Sanitize logging

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
@@ -147,16 +147,7 @@ public final class SessionImpl implements Session {
                 exceptions.forEach(closeException::addSuppressed);
                 throw closeException;
             }
-            logger.info(
-                    // Located x/y: x times locate invoked; y times locate produced "hit" (key found)
-                    // Retrieved x: x files were pulled from cache (failed retrieve fails the build)
-                    // Cached x/y: x times asked to cache a file; y times cache happened (as cache may refuse)
-                    "Mimir session closed (LOCATED={}/{} RETRIEVED={} CACHED={}/{})",
-                    stats.locate(),
-                    stats.locateSuccess(),
-                    stats.transfer(),
-                    stats.store(),
-                    stats.storeSuccess());
+            logger.info("Mimir session closed (RETRIEVED={} CACHED={})", stats.transfer(), stats.storeSuccess());
         }
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
@@ -147,7 +147,7 @@ public final class SessionImpl implements Session {
                 exceptions.forEach(closeException::addSuppressed);
                 throw closeException;
             }
-            logger.info("Mimir session closed (RETRIEVED={} CACHED={})", stats.transfer(), stats.storeSuccess());
+            logger.info("Mimir session closed (RETRIEVED={} CACHED={})", stats.transferSuccess(), stats.storeSuccess());
         }
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/Stats.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/Stats.java
@@ -11,11 +11,17 @@ import java.util.Optional;
 import java.util.concurrent.atomic.LongAdder;
 
 public final class Stats {
+    // metadata queried
     private final LongAdder locate = new LongAdder();
+    // metadata found
     private final LongAdder locateSuccess = new LongAdder();
+    // content transferred (retrieval from cache) asked
     private final LongAdder transfer = new LongAdder();
+    // content transferred (retrieval from cache) succeeded
     private final LongAdder transferSuccess = new LongAdder();
+    // store (put to cache) asked
     private final LongAdder store = new LongAdder();
+    // store (put to cache) succeeded; cache did not refuse operation
     private final LongAdder storeSuccess = new LongAdder();
 
     public long locate() {

--- a/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
@@ -127,7 +127,8 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
             List<Version> versions = rangeResult.getVersions();
             if (versions.size() > 1) {
                 String latest = versions.get(versions.size() - 1).toString();
-                if (!Objects.equals(mimirVersion, latest)) {
+                // only for locally built versions; we do not publish snapshots
+                if (!latest.endsWith("-SNAPSHOT") && !Objects.equals(mimirVersion, latest)) {
                     logger.info("Please upgrade to Mimir version {} (you are using version {})", latest, mimirVersion);
                 }
             } else {

--- a/it/extension-its/pom.xml
+++ b/it/extension-its/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <maven3Version>3.9.9</maven3Version>
-    <maven4Version>4.0.0-rc-2</maven4Version>
+    <maven4Version>4.0.0-rc-3</maven4Version>
   </properties>
 
   <dependencies>

--- a/it/extension-its/src/it/no-http-traffic/verify.groovy
+++ b/it/extension-its/src/it/no-http-traffic/verify.groovy
@@ -8,9 +8,9 @@ String log = buildLog.text
 // nothing should be cached as cache was primed.
 // Also Maven 3 vs 4 diff: they resolve differently
 if (log.contains('Apache Maven 3.9.9')) {
-    assert log.contains('[INFO] Mimir session closed (LOCATED=203/203 RETRIEVED=203 CACHED=0/0)')
+    assert log.contains('[INFO] Mimir session closed (RETRIEVED=203 CACHED=0)')
 } else if (log.contains('Apache Maven 4.0.0')) {
-    assert log.contains('[INFO] Mimir session closed (LOCATED=195/195 RETRIEVED=195 CACHED=0/0)')
+    assert log.contains('[INFO] Mimir session closed (RETRIEVED=161 CACHED=0)')
 } else {
     throw new IllegalStateException("What Maven version is this?")
 }


### PR DESCRIPTION
Report only meaningful stats.
Also, do not warn for locally built Mimir versions.

Fixes #36 