### PR TITLE
Entry cleanup

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/node/Entry.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/node/Entry.java
@@ -7,6 +7,9 @@
  */
 package eu.maveniverse.maven.mimir.shared.node;
 
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
 import java.util.Map;
 
 public interface Entry {
@@ -23,4 +26,27 @@ public interface Entry {
      * Entry checksums.
      */
     Map<String, String> checksums();
+
+    default long getContentLength() {
+        return Long.parseLong(requireNonNull(metadata().get(Entry.CONTENT_LENGTH), Entry.CONTENT_LENGTH));
+    }
+
+    static void setContentLength(Map<String, String> metadata, long contentLength) {
+        requireNonNull(metadata, "metadata cannot be null");
+        if (contentLength < 0) {
+            throw new IllegalArgumentException("Content length cannot be negative");
+        }
+        metadata.put(Entry.CONTENT_LENGTH, Long.toString(contentLength));
+    }
+
+    default Instant getContentLastModified() {
+        return Instant.ofEpochMilli(Long.parseLong(
+                requireNonNull(metadata().get(Entry.CONTENT_LAST_MODIFIED), Entry.CONTENT_LAST_MODIFIED)));
+    }
+
+    static void setContentLastModified(Map<String, String> metadata, Instant contentLastModified) {
+        requireNonNull(metadata, "metadata cannot be null");
+        requireNonNull(contentLastModified, "Content last modified cannot be null");
+        metadata.put(Entry.CONTENT_LAST_MODIFIED, Long.toString(contentLastModified.toEpochMilli()));
+    }
 }

--- a/node/file/src/main/java/eu/maveniverse/maven/mimir/node/file/FileNode.java
+++ b/node/file/src/main/java/eu/maveniverse/maven/mimir/node/file/FileNode.java
@@ -142,8 +142,8 @@ public final class FileNode extends NodeSupport implements SystemNode {
                 Files.setLastModifiedTime(f.getPath(), fileTime);
             }
 
-            metadata.put(Entry.CONTENT_LENGTH, Long.toString(Files.size(file)));
-            metadata.put(Entry.CONTENT_LAST_MODIFIED, Long.toString(fileTime.toMillis()));
+            Entry.setContentLength(metadata, Files.size(file));
+            Entry.setContentLastModified(metadata, fileTime.toInstant());
             storeMetadata(path, mergeEntry(metadata, checksumEnforcer.getChecksums()));
             f.move();
         }
@@ -158,10 +158,8 @@ public final class FileNode extends NodeSupport implements SystemNode {
     private FileEntry createEntry(Path file, Map<String, String> metadata, Map<String, String> checksums)
             throws IOException {
         HashMap<String, String> md = new HashMap<>(metadata);
-        md.put(Entry.CONTENT_LENGTH, Long.toString(Files.size(file)));
-        md.put(
-                Entry.CONTENT_LAST_MODIFIED,
-                Long.toString(Files.getLastModifiedTime(file).toMillis()));
+        Entry.setContentLength(md, Files.size(file));
+        Entry.setContentLastModified(md, Files.getLastModifiedTime(file).toInstant());
         return new FileEntry(md, checksums, file, mayLink);
     }
 
@@ -196,10 +194,8 @@ public final class FileNode extends NodeSupport implements SystemNode {
 
     private void recreateMetadata(Path file) throws IOException {
         HashMap<String, String> metadata = new HashMap<>();
-        metadata.put(Entry.CONTENT_LENGTH, Long.toString(Files.size(file)));
-        metadata.put(
-                Entry.CONTENT_LAST_MODIFIED,
-                Long.toString(Files.getLastModifiedTime(file).toMillis()));
+        Entry.setContentLength(metadata, Files.size(file));
+        Entry.setContentLastModified(metadata, Files.getLastModifiedTime(file).toInstant());
         Map<String, String> checksums = calculate(
                 file,
                 checksumAlgorithms().stream()

--- a/node/file/src/test/java/eu/maveniverse/maven/mimir/node/file/FileNodeTest.java
+++ b/node/file/src/test/java/eu/maveniverse/maven/mimir/node/file/FileNodeTest.java
@@ -57,7 +57,7 @@ public class FileNodeTest {
             entry = fileNode.locate(keyMapper.apply(central, junit));
             assertTrue(entry.isPresent());
             SystemEntry systemEntry = entry.orElseThrow();
-            assertEquals("12", systemEntry.metadata().get(SystemEntry.CONTENT_LENGTH));
+            assertEquals(12, systemEntry.getContentLength());
             assertEquals(
                     "2ef7bde608ce5404e97d5f042f95f89f1c232871",
                     systemEntry.checksums().get(Sha1ChecksumAlgorithmFactory.NAME));
@@ -99,7 +99,7 @@ public class FileNodeTest {
             entry = fileNode.locate(keyMapper.apply(central, junit));
             assertTrue(entry.isPresent());
             SystemEntry systemEntry = entry.orElseThrow();
-            assertEquals("12", systemEntry.metadata().get(SystemEntry.CONTENT_LENGTH));
+            assertEquals(12, systemEntry.getContentLength());
             assertEquals(
                     "2ef7bde608ce5404e97d5f042f95f89f1c232871",
                     systemEntry.checksums().get(Sha1ChecksumAlgorithmFactory.NAME));

--- a/node/minio/src/test/java/eu/maveniverse/maven/mimir/node/minio/MinioNodeTest.java
+++ b/node/minio/src/test/java/eu/maveniverse/maven/mimir/node/minio/MinioNodeTest.java
@@ -73,7 +73,7 @@ public class MinioNodeTest {
                     entry = minioNode.locate(keyMapper.apply(central, junit));
                     assertTrue(entry.isPresent());
                     SystemEntry systemEntry = entry.orElseThrow();
-                    assertEquals("12", systemEntry.metadata().get(SystemEntry.CONTENT_LENGTH));
+                    assertEquals(12, systemEntry.getContentLength());
                     assertEquals(
                             "2ef7bde608ce5404e97d5f042f95f89f1c232871",
                             systemEntry.checksums().get(Sha1ChecksumAlgorithmFactory.NAME));


### PR DESCRIPTION
Collect all scattered conversions/setters to single place. Provide getter for content length and content last modified.