### PR TITLE
Move out transport

### DIFF
--- a/daemon-protocol/src/main/java/eu/maveniverse/maven/mimir/daemon/protocol/Handle.java
+++ b/daemon-protocol/src/main/java/eu/maveniverse/maven/mimir/daemon/protocol/Handle.java
@@ -14,8 +14,13 @@ import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
 import java.nio.channels.ByteChannel;
 import java.nio.channels.Channels;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.msgpack.core.MessagePack;
@@ -32,7 +37,51 @@ public class Handle implements Closeable {
     private final DataOutputStream outputStream;
     private final DataInputStream inputStream;
 
-    public Handle(ByteChannel byteChannel) {
+    public interface ServerHandle extends Closeable {
+        boolean isOpen();
+
+        Handle accept() throws IOException;
+    }
+
+    public static ServerHandle serverDomainSocket(Path domainSocketPath) throws IOException {
+        requireNonNull(domainSocketPath, "domainSocketPath");
+        UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(domainSocketPath);
+        ServerSocketChannel serverSocketChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+        serverSocketChannel.configureBlocking(true);
+        serverSocketChannel.bind(socketAddress);
+        return new ServerHandle() {
+            @Override
+            public boolean isOpen() {
+                return serverSocketChannel.isOpen();
+            }
+
+            @Override
+            public Handle accept() throws IOException {
+                return new Handle(serverSocketChannel.accept());
+            }
+
+            @Override
+            public void close() throws IOException {
+                serverSocketChannel.close();
+            }
+        };
+    }
+
+    public static Handle clientDomainSocket(Path domainSocketPath) throws IOException {
+        requireNonNull(domainSocketPath, "domainSocketPath");
+        SocketChannel socketChannel = SocketChannel.open(UnixDomainSocketAddress.of(domainSocketPath));
+        socketChannel.configureBlocking(true);
+        return new Handle(socketChannel);
+    }
+
+    /**
+     * This method is used in tests.
+     */
+    public static Handle byteChannel(ByteChannel byteChannel) {
+        return new Handle(byteChannel);
+    }
+
+    private Handle(ByteChannel byteChannel) {
         this.channel = requireNonNull(byteChannel, "byteChannel");
         this.outputStream = new DataOutputStream(Channels.newOutputStream(channel));
         this.inputStream = new DataInputStream(Channels.newInputStream(channel));

--- a/daemon-protocol/src/main/java/eu/maveniverse/maven/mimir/daemon/protocol/Handle.java
+++ b/daemon-protocol/src/main/java/eu/maveniverse/maven/mimir/daemon/protocol/Handle.java
@@ -45,10 +45,9 @@ public class Handle implements Closeable {
 
     public static ServerHandle serverDomainSocket(Path domainSocketPath) throws IOException {
         requireNonNull(domainSocketPath, "domainSocketPath");
-        UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(domainSocketPath);
         ServerSocketChannel serverSocketChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
         serverSocketChannel.configureBlocking(true);
-        serverSocketChannel.bind(socketAddress);
+        serverSocketChannel.bind(UnixDomainSocketAddress.of(domainSocketPath));
         return new ServerHandle() {
             @Override
             public boolean isOpen() {
@@ -69,8 +68,9 @@ public class Handle implements Closeable {
 
     public static Handle clientDomainSocket(Path domainSocketPath) throws IOException {
         requireNonNull(domainSocketPath, "domainSocketPath");
-        SocketChannel socketChannel = SocketChannel.open(UnixDomainSocketAddress.of(domainSocketPath));
+        SocketChannel socketChannel = SocketChannel.open(StandardProtocolFamily.UNIX);
         socketChannel.configureBlocking(true);
+        socketChannel.connect(UnixDomainSocketAddress.of(domainSocketPath));
         return new Handle(socketChannel);
     }
 

--- a/daemon-protocol/src/test/java/eu/maveniverse/maven/mimir/daemon/protocol/ProtocolTest.java
+++ b/daemon-protocol/src/test/java/eu/maveniverse/maven/mimir/daemon/protocol/ProtocolTest.java
@@ -24,7 +24,7 @@ public class ProtocolTest {
             Thread client = new Thread(
                     () -> {
                         try {
-                            Handle handle = new Handle(clientSck);
+                            Handle handle = Handle.byteChannel(clientSck);
                             handle.writeRequest(Request.hello(Map.of("hello", "world")));
                             messages.add(handle.readResponse());
                         } catch (IOException e) {
@@ -35,7 +35,7 @@ public class ProtocolTest {
             Thread server = new Thread(
                     () -> {
                         try {
-                            Handle handle = new Handle(serverSck);
+                            Handle handle = Handle.byteChannel(serverSck);
                             Request request = handle.readRequest();
                             messages.add(request);
                             handle.writeResponse(Response.okMessage(request, "hi!"));

--- a/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
+++ b/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
@@ -144,9 +144,8 @@ public class Daemon implements Closeable {
                 logger.warn("Failed to delete socket path: {}", socketPath, e);
             }
         }));
-
         this.serverHandle = Handle.serverDomainSocket(socketPath);
-        ;
+
         logger.info("Mimir Daemon {} started", config.mimirVersion().orElse("UNKNOWN"));
         logger.info("  PID: {}", ProcessHandle.current().pid());
         logger.info("  Properties: {}", config.basedir().resolve(config.propertiesPath()));

--- a/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
+++ b/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
+import eu.maveniverse.maven.mimir.daemon.protocol.Handle;
 import eu.maveniverse.maven.mimir.daemon.protocol.Request;
 import eu.maveniverse.maven.mimir.daemon.protocol.Session;
 import eu.maveniverse.maven.mimir.shared.Config;
@@ -20,11 +21,7 @@ import eu.maveniverse.maven.mimir.shared.node.SystemNode;
 import eu.maveniverse.maven.mimir.shared.node.SystemNodeFactory;
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.StandardProtocolFamily;
-import java.net.UnixDomainSocketAddress;
 import java.nio.channels.AsynchronousCloseException;
-import java.nio.channels.ServerSocketChannel;
-import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -109,7 +106,7 @@ public class Daemon implements Closeable {
     private final Logger logger = LoggerFactory.getLogger(Daemon.class);
 
     private final Config config;
-    private final ServerSocketChannel serverSocketChannel;
+    private final Handle.ServerHandle serverHandle;
     private final ExecutorService executor;
     private final SystemNode<?> systemNode;
     private final List<RemoteNode<?>> remoteNodes;
@@ -148,17 +145,13 @@ public class Daemon implements Closeable {
             }
         }));
 
-        UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(socketPath);
-        ServerSocketChannel serverSocketChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
-        serverSocketChannel.configureBlocking(true);
-        serverSocketChannel.bind(socketAddress);
-
-        this.serverSocketChannel = serverSocketChannel;
+        this.serverHandle = Handle.serverDomainSocket(socketPath);
+        ;
         logger.info("Mimir Daemon {} started", config.mimirVersion().orElse("UNKNOWN"));
         logger.info("  PID: {}", ProcessHandle.current().pid());
         logger.info("  Properties: {}", config.basedir().resolve(config.propertiesPath()));
         logger.info("  Supported checksums: {}", checksumAlgorithmFactories.keySet());
-        logger.info("  Socket: {}", socketAddress);
+        logger.info("  Socket: {}", socketPath);
         logger.info("  System Node: {}", systemNode);
         logger.info("  Using checksums: {}", systemNode.checksumAlgorithms());
         logger.info("  {} remote node(s):", remoteNodes.size());
@@ -175,10 +168,10 @@ public class Daemon implements Closeable {
 
         executor.submit(() -> {
             try {
-                while (serverSocketChannel.isOpen()) {
-                    SocketChannel socketChannel = serverSocketChannel.accept();
+                while (serverHandle.isOpen()) {
+                    Handle handle = serverHandle.accept();
                     executor.submit(new DaemonServer(
-                            socketChannel, daemonData, systemNode, remoteNodes, clientPredicate, this::close));
+                            handle, daemonData, systemNode, remoteNodes, clientPredicate, this::close));
                 }
             } catch (AsynchronousCloseException ignored) {
                 // we are done
@@ -192,7 +185,7 @@ public class Daemon implements Closeable {
     public void close() {
         try {
             try {
-                serverSocketChannel.close();
+                serverHandle.close();
             } catch (Exception e) {
                 logger.warn("Error closing server socket channel", e);
             }

--- a/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/DaemonServer.java
+++ b/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/DaemonServer.java
@@ -29,7 +29,6 @@ import eu.maveniverse.maven.mimir.shared.node.SystemEntry;
 import eu.maveniverse.maven.mimir.shared.node.SystemNode;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.channels.SocketChannel;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -51,13 +50,13 @@ final class DaemonServer implements Runnable {
     private final Runnable shutdownHook;
 
     DaemonServer(
-            SocketChannel socketChannel,
+            Handle handle,
             Map<String, String> daemonData,
             SystemNode<?> systemNode,
             List<RemoteNode<?>> remoteNodes,
             Predicate<Request> clientPredicate,
             Runnable shutdownHook) {
-        this.handle = new Handle(socketChannel);
+        this.handle = handle;
         this.daemonData = daemonData;
         this.systemNode = systemNode;
         this.remoteNodes = remoteNodes;


### PR DESCRIPTION
For now we have simple transport, so move the logic out to single spot, and drop redundant creation at various places.