### PR TITLE
Move "simple" things to their place

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionFactoryImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionFactoryImpl.java
@@ -52,7 +52,7 @@ public final class SessionFactoryImpl implements SessionFactory {
         if (localNodeFactory == null) {
             throw new IllegalArgumentException("Unknown local node: " + sessionConfig.localNode());
         }
-        LocalNode localNode = localNodeFactory.createNode(config);
+        LocalNode<?> localNode = localNodeFactory.createNode(config);
 
         KeyMapperFactory keyMapperFactory = nameMapperFactories.get(sessionConfig.keyMapper());
         if (keyMapperFactory == null) {

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
@@ -33,14 +33,14 @@ public final class SessionImpl implements Session {
     private final Predicate<RemoteRepository> repositoryPredicate;
     private final Predicate<Artifact> artifactPredicate;
     private final BiFunction<RemoteRepository, Artifact, URI> keyMapper;
-    private final LocalNode localNode;
+    private final LocalNode<?> localNode;
     private final Stats stats;
 
     public SessionImpl(
             Predicate<RemoteRepository> repositoryPredicate,
             Predicate<Artifact> artifactPredicate,
             BiFunction<RemoteRepository, Artifact, URI> keyMapper,
-            LocalNode localNode) {
+            LocalNode<?> localNode) {
         this.closed = new AtomicBoolean(false);
         this.repositoryPredicate = requireNonNull(repositoryPredicate, "repositoryPredicate");
         this.artifactPredicate = requireNonNull(artifactPredicate, "artifactPredicate");

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/naming/SimpleKeyMapperFactory.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/naming/SimpleKeyMapperFactory.java
@@ -12,8 +12,12 @@ import static java.util.Objects.requireNonNull;
 import eu.maveniverse.maven.mimir.shared.Config;
 import eu.maveniverse.maven.mimir.shared.naming.KeyMapper;
 import eu.maveniverse.maven.mimir.shared.naming.KeyMapperFactory;
+import java.net.URI;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 
 @Singleton
 @Named(SimpleKeyMapperFactory.NAME)
@@ -32,5 +36,27 @@ public final class SimpleKeyMapperFactory implements KeyMapperFactory {
      * More logic may be needed for more complex scenarios, like proper identification of remote repositories,
      * support repo aliases, mirrors, etc.
      */
-    private static class SimpleKeyMapper implements KeyMapper {}
+    public static class SimpleKeyMapper implements KeyMapper {
+        /**
+         * Provides default and simplistic "container" implementation.
+         */
+        public String container(RemoteRepository repository) {
+            return repository.getId();
+        }
+
+        /**
+         * Provides default and simplistic "name" implementation.
+         */
+        public String name(Artifact artifact) {
+            return ArtifactIdUtils.toId(artifact);
+        }
+
+        /**
+         * Creates a cache key according to naming strategy.
+         */
+        @Override
+        public URI apply(RemoteRepository remoteRepository, Artifact artifact) {
+            return URI.create("mimir:artifact:" + container(remoteRepository) + ":" + name(artifact));
+        }
+    }
 }

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/naming/KeyMapper.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/naming/KeyMapper.java
@@ -11,28 +11,5 @@ import java.net.URI;
 import java.util.function.BiFunction;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.util.artifact.ArtifactIdUtils;
 
-public interface KeyMapper extends BiFunction<RemoteRepository, Artifact, URI> {
-    /**
-     * Provides default and simplistic "container" implementation.
-     */
-    default String container(RemoteRepository repository) {
-        return repository.getId();
-    }
-
-    /**
-     * Provides default and simplistic "name" implementation.
-     */
-    default String name(Artifact artifact) {
-        return ArtifactIdUtils.toId(artifact);
-    }
-
-    /**
-     * Creates a cache key according to naming strategy.
-     */
-    @Override
-    default URI apply(RemoteRepository remoteRepository, Artifact artifact) {
-        return URI.create("mimir:artifact:" + container(remoteRepository) + ":" + name(artifact));
-    }
-}
+public interface KeyMapper extends BiFunction<RemoteRepository, Artifact, URI> {}

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/naming/KeyResolver.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/naming/KeyResolver.java
@@ -9,48 +9,5 @@ package eu.maveniverse.maven.mimir.shared.naming;
 
 import java.net.URI;
 import java.util.function.Function;
-import org.eclipse.aether.artifact.Artifact;
-import org.eclipse.aether.artifact.DefaultArtifact;
 
-public interface KeyResolver extends Function<URI, Key> {
-    /**
-     * Provides "path" for artifact.
-     */
-    default String artifactPath(Artifact artifact) {
-        String name = artifact.getGroupId() + "/" + artifact.getArtifactId() + "/" + artifact.getBaseVersion() + "/"
-                + artifact.getArtifactId() + "-" + artifact.getVersion();
-        if (artifact.getClassifier() != null && !artifact.getClassifier().trim().isEmpty()) {
-            name += "-" + artifact.getClassifier();
-        }
-        name += "." + artifact.getExtension();
-        return name;
-    }
-
-    /**
-     * Resolves a cache key according to naming strategy.
-     */
-    @Override
-    default Key apply(URI key) {
-        if (key.isOpaque()) {
-            if ("mimir".equals(key.getScheme())) {
-                String ssp = key.getSchemeSpecificPart();
-                if (ssp.startsWith("artifact:")) {
-                    String[] bits = ssp.substring(9).split(":", 2);
-                    if (bits.length == 2) {
-                        String container = bits[0];
-                        Artifact artifact = new DefaultArtifact(bits[1]);
-                        return Key.of(container, artifactPath(artifact));
-                    }
-                } else if (ssp.startsWith("file:")) {
-                    String[] bits = ssp.substring(5).split(":", 2);
-                    if (bits.length == 2) {
-                        String container = bits[0];
-                        String path = bits[1];
-                        return Key.of(container, path);
-                    }
-                }
-            }
-        }
-        throw new IllegalArgumentException("Unexpected URI");
-    }
-}
+public interface KeyResolver extends Function<URI, Key> {}


### PR DESCRIPTION
Right now iface offered as default methods the simple methods and simple class just inherited them. This was misleading.

Move simple code to simple classes, and make them public static so possible to extend if needed.