### PR TITLE
Add new IT for new feature

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/Config.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/Config.java
@@ -216,7 +216,7 @@ public interface Config {
         if (basedir == null) {
             return getCanonicalPath(discoverUserHomeDirectory().resolve(".mimir"));
         }
-        return getCanonicalPath(Path.of(basedir));
+        return getCanonicalPath(Path.of(System.getProperty("user.dir")).resolve(basedir));
     }
 
     static Path discoverUserHomeDirectory() {

--- a/it/extension-its/pom.xml
+++ b/it/extension-its/pom.xml
@@ -131,6 +131,7 @@
                   <mavenHome>${project.build.directory}/dependency/apache-maven-${maven3Version}</mavenHome>
                   <cloneProjectsTo>${project.build.directory}/mvn3-it</cloneProjectsTo>
                   <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+                  <settingsFile>${project.build.directory}/it-user/.m2/settings.xml</settingsFile>
                   <mavenOpts>-Duser.home=${project.build.directory}/it-user</mavenOpts>
                   <properties>
                     <mimir.daemon.passOnBasedir>true</mimir.daemon.passOnBasedir>
@@ -154,6 +155,7 @@
                   <mavenHome>${project.build.directory}/dependency/apache-maven-${maven4Version}</mavenHome>
                   <cloneProjectsTo>${project.build.directory}/mvn4-it</cloneProjectsTo>
                   <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+                  <settingsFile>${project.build.directory}/it-user/.m2/settings.xml</settingsFile>
                   <mavenOpts>-Duser.home=${project.build.directory}/it-user</mavenOpts>
                   <properties>
                     <mimir.daemon.passOnBasedir>true</mimir.daemon.passOnBasedir>

--- a/it/extension-its/src/it/no-http-traffic/invoker.properties
+++ b/it/extension-its/src/it/no-http-traffic/invoker.properties
@@ -1,2 +1,6 @@
-invoker.goals.1 = -V -e clean install -Dmimir.daemon.autostop -Dmaven.repo.local=first -Dmaven.repo.local.tail=../../it-repo-tail
-invoker.goals.2 = -V -e clean install -Dmimir.daemon.autostop -Dmaven.repo.local=second -Dmaven.repo.local.tail=../../it-repo-tail
+# 1st: mimir empty && local repo empty
+invoker.goals.1 = -V -e clean install -l first.log -Dmimir.daemon.autostop -Dmimir.basedir=mimir1 -Dmimir.daemon.passOnBasedir -Dmaven.repo.local=first -Dmaven.repo.local.tail=../../it-repo-tail
+# 2nd: mimir primed && local repo empty
+invoker.goals.2 = -V -e clean install -l second.log -Dmimir.daemon.autostop -Dmimir.basedir=mimir1 -Dmimir.daemon.passOnBasedir -Dmaven.repo.local=second -Dmaven.repo.local.tail=../../it-repo-tail
+# 3rd: mimir empty && local repo primed
+invoker.goals.3 = -V -e clean install -l third.log -Dmimir.daemon.autostop -Dmimir.basedir=mimir2 -Dmimir.daemon.passOnBasedir -Dmaven.repo.local=second -Dmaven.repo.local.tail=../../it-repo-tail

--- a/it/extension-its/src/it/no-http-traffic/verify.groovy
+++ b/it/extension-its/src/it/no-http-traffic/verify.groovy
@@ -1,16 +1,27 @@
-File buildLog = new File( basedir, 'build.log' )
-assert buildLog.exists()
+File firstLog = new File( basedir, 'first.log' )
+assert firstLog.exists()
+String first = firstLog.text
 
-String log = buildLog.text
+File secondLog = new File( basedir, 'second.log' )
+assert secondLog.exists()
+String second = secondLog.text
+
+File thirdLog = new File( basedir, 'third.log' )
+assert thirdLog.exists()
+String third = thirdLog.text
 
 // Lets make strict assertion
 // Explanation: cache was primed, so aside of "tail repo" everything else was located and retrieved, and
 // nothing should be cached as cache was primed.
 // Also Maven 3 vs 4 diff: they resolve differently
-if (log.contains('Apache Maven 3.9.9')) {
-    assert log.contains('[INFO] Mimir session closed (RETRIEVED=216 CACHED=0)')
-} else if (log.contains('Apache Maven 4.0.0')) {
-    assert log.contains('[INFO] Mimir session closed (RETRIEVED=174 CACHED=0)')
+if (first.contains('Apache Maven 3.9.9')) {
+    assert first.contains('[INFO] Mimir session closed (RETRIEVED=0 CACHED=216)') // both empty: mimir connector cached
+    assert second.contains('[INFO] Mimir session closed (RETRIEVED=216 CACHED=0)') // mimir primed: all was retrieved
+    assert third.contains('[INFO] Mimir session closed (RETRIEVED=0 CACHED=216)') // local repo primed: all was cached
+} else if (first.contains('Apache Maven 4.0.0')) {
+    assert first.contains('[INFO] Mimir session closed (RETRIEVED=0 CACHED=174)')
+    assert second.contains('[INFO] Mimir session closed (RETRIEVED=174 CACHED=0)')
+    assert third.contains('[INFO] Mimir session closed (RETRIEVED=0 CACHED=174)')
 } else {
     throw new IllegalStateException("What Maven version is this?")
 }

--- a/it/extension-its/src/it/no-http-traffic/verify.groovy
+++ b/it/extension-its/src/it/no-http-traffic/verify.groovy
@@ -11,9 +11,7 @@ assert thirdLog.exists()
 String third = thirdLog.text
 
 // Lets make strict assertion
-// Explanation: cache was primed, so aside of "tail repo" everything else was located and retrieved, and
-// nothing should be cached as cache was primed.
-// Also Maven 3 vs 4 diff: they resolve differently
+// Also, consider Maven 3 vs 4 diff: they resolve differently
 if (first.contains('Apache Maven 3.9.9')) {
     assert first.contains('[INFO] Mimir session closed (RETRIEVED=0 CACHED=216)') // both empty: mimir connector cached
     assert second.contains('[INFO] Mimir session closed (RETRIEVED=216 CACHED=0)') // mimir primed: all was retrieved

--- a/it/extension-its/src/it/user-home/.m2/settings.xml
+++ b/it/extension-its/src/it/user-home/.m2/settings.xml
@@ -1,0 +1,4 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <!-- empty -->
+</settings>


### PR DESCRIPTION
Mimir is now capable to fill in caches in cases when only local repository contains cached items not in mimir caches yet. Added IT to cover this.

Now IT does:
* both empty -- mimir cache is populated and so is local repository
* local repo empty -- mimir cache populates local repo (no HTTP request)
* mimir empty -- mimir cache is populated from primed local repo