### PR TITLE
Prevent different versions to join cluster

### DIFF
--- a/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNode.java
+++ b/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNode.java
@@ -170,7 +170,7 @@ public class JGroupsNode extends RemoteNodeSupport<PublisherRemoteEntry> impleme
     @Override
     public String toString() {
         return getClass().getSimpleName() + " (distance=" + distance + " channel=" + channel.getAddress()
-                + " publisher=" + publisher + ")";
+                + " clusterName=" + channel.getClusterName() + " publisher=" + publisher + ")";
     }
 
     @Override

--- a/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNodeConfig.java
+++ b/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNodeConfig.java
@@ -17,12 +17,18 @@ public class JGroupsNodeConfig {
     public static JGroupsNodeConfig with(Config config) throws IOException {
         requireNonNull(config, "config");
 
+        String groupSuffix = "@n/a";
+        if (config.mimirVersion().isPresent()) {
+            String version = config.mimirVersion().orElseThrow();
+            groupSuffix = "@" + version.substring(0, version.lastIndexOf('.'));
+        }
+
         boolean enabled = true;
         boolean publisherEnabled = true;
         String publisherTransport = "socket";
         String jgroupsProps = "udp-new.xml";
         String jgroupsNodeName = InetAddress.getLocalHost().getHostName();
-        String jgroupsClusterName = "mimir-jgroups";
+        String jgroupsClusterName = "mimir-jgroups" + groupSuffix;
         String jgroupsInterface = null;
 
         if (config.effectiveProperties().containsKey("mimir.jgroups.enabled")) {


### PR DESCRIPTION
Members of the cluster should be same major.minor aligned as otherwise they may be quite different versioned and this may cause problems.

If user overrides cluster name, it is his own responsibility to make sure this is ensured.