### PR TITLE
Cache central only, but provide user config for list of cached reposes

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionConfig.java
@@ -13,8 +13,6 @@ import eu.maveniverse.maven.mimir.shared.Config;
 import eu.maveniverse.maven.mimir.shared.impl.naming.SimpleKeyMapperFactory;
 import eu.maveniverse.maven.mimir.shared.naming.RemoteRepositories;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 public final class SessionConfig {
@@ -23,7 +21,7 @@ public final class SessionConfig {
 
         String keyMapper = SimpleKeyMapperFactory.NAME;
         String localNode = "daemon";
-        Set<String> repositories = Collections.singleton(RemoteRepositories.CENTRAL_REPOSITORY_ID);
+        Set<String> repositories = Set.of(RemoteRepositories.CENTRAL_REPOSITORY_ID);
 
         if (config.effectiveProperties().containsKey("mimir.session.keyMapper")) {
             keyMapper = config.effectiveProperties().get("mimir.session.keyMapper");
@@ -33,7 +31,7 @@ public final class SessionConfig {
         }
         if (config.effectiveProperties().containsKey("mimir.session.repositories")) {
             String value = config.effectiveProperties().get("mimir.session.repositories");
-            repositories = new HashSet<>(Arrays.asList(value.split(",")));
+            repositories = Set.copyOf(Arrays.asList(value.split(",")));
         }
 
         return new SessionConfig(keyMapper, localNode, repositories);

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionConfig.java
@@ -42,9 +42,9 @@ public final class SessionConfig {
     private final Set<String> repositories;
 
     private SessionConfig(String keyMapper, String localNode, Set<String> repositories) {
-        this.keyMapper = keyMapper;
-        this.localNode = localNode;
-        this.repositories = repositories;
+        this.keyMapper = requireNonNull(keyMapper);
+        this.localNode = requireNonNull(localNode);
+        this.repositories = requireNonNull(repositories);
     }
 
     public String keyMapper() {

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionConfig.java
@@ -11,6 +11,11 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.mimir.shared.Config;
 import eu.maveniverse.maven.mimir.shared.impl.naming.SimpleKeyMapperFactory;
+import eu.maveniverse.maven.mimir.shared.naming.RemoteRepositories;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 public final class SessionConfig {
     public static SessionConfig with(Config config) {
@@ -18,6 +23,7 @@ public final class SessionConfig {
 
         String keyMapper = SimpleKeyMapperFactory.NAME;
         String localNode = "daemon";
+        Set<String> repositories = Collections.singleton(RemoteRepositories.CENTRAL_REPOSITORY_ID);
 
         if (config.effectiveProperties().containsKey("mimir.session.keyMapper")) {
             keyMapper = config.effectiveProperties().get("mimir.session.keyMapper");
@@ -25,20 +31,22 @@ public final class SessionConfig {
         if (config.effectiveProperties().containsKey("mimir.session.localNode")) {
             localNode = config.effectiveProperties().get("mimir.session.localNode");
         }
+        if (config.effectiveProperties().containsKey("mimir.session.repositories")) {
+            String value = config.effectiveProperties().get("mimir.session.repositories");
+            repositories = new HashSet<>(Arrays.asList(value.split(",")));
+        }
 
-        return new SessionConfig(keyMapper, localNode);
-    }
-
-    public static SessionConfig of(String nameMapper, String localNode) {
-        return new SessionConfig(requireNonNull(nameMapper, "nameMapper"), requireNonNull(localNode, "localNode"));
+        return new SessionConfig(keyMapper, localNode, repositories);
     }
 
     private final String keyMapper;
     private final String localNode;
+    private final Set<String> repositories;
 
-    private SessionConfig(String keyMapper, String localNode) {
+    private SessionConfig(String keyMapper, String localNode, Set<String> repositories) {
         this.keyMapper = keyMapper;
         this.localNode = localNode;
+        this.repositories = repositories;
     }
 
     public String keyMapper() {
@@ -47,5 +55,9 @@ public final class SessionConfig {
 
     public String localNode() {
         return localNode;
+    }
+
+    public Set<String> repositories() {
+        return repositories;
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/naming/RemoteRepositories.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/naming/RemoteRepositories.java
@@ -10,8 +10,10 @@ package eu.maveniverse.maven.mimir.shared.naming;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.eclipse.aether.repository.RemoteRepository;
 
@@ -19,7 +21,7 @@ import org.eclipse.aether.repository.RemoteRepository;
  * Some handy predicates for {@link RemoteRepository} instances.
  */
 public final class RemoteRepositories {
-    private static final String CENTRAL_REPOSITORY_ID = "central";
+    public static final String CENTRAL_REPOSITORY_ID = "central";
     private static final Collection<String> CENTRAL_URLS = List.of(
             "https://repo.maven.apache.org/maven2",
             "https://repo1.maven.org/maven2",
@@ -31,13 +33,14 @@ public final class RemoteRepositories {
      * For simplicity's sake: this one supports ONLY Maven Central (direct access).
      * Repository is supported if:
      * <ul>
-     *     <li>the {@link #httpsReleaseDirectOnlyWithId(String)} supports it; id is "central"</li>
+     *     <li>the {@link #httpsReleaseDirectOnlyWithIds(Set)} supports it; id is "central"</li>
      *     <li>the URL is one of "real" Central URLs</li>
      * </ul>
      */
     public static Predicate<RemoteRepository> centralDirectOnly() {
-        return httpsReleaseDirectOnlyWithId(CENTRAL_REPOSITORY_ID).and(remoteRepository -> CENTRAL_URLS.stream()
-                .anyMatch(u -> remoteRepository.getUrl().startsWith(u)));
+        return httpsReleaseDirectOnlyWithIds(Collections.singleton(CENTRAL_REPOSITORY_ID))
+                .and(remoteRepository -> CENTRAL_URLS.stream()
+                        .anyMatch(u -> remoteRepository.getUrl().startsWith(u)));
     }
 
     /**
@@ -47,9 +50,9 @@ public final class RemoteRepositories {
      *     <li>repository.id equals to given ID</li>
      * </ul>
      */
-    public static Predicate<RemoteRepository> httpsReleaseDirectOnlyWithId(String repositoryId) {
-        requireNonNull(repositoryId, "repositoryId");
-        return httpsReleaseDirectOnly().and(remoteRepository -> repositoryId.equals(remoteRepository.getId()));
+    public static Predicate<RemoteRepository> httpsReleaseDirectOnlyWithIds(Set<String> repositoryIds) {
+        requireNonNull(repositoryIds, "repositoryIds");
+        return httpsReleaseDirectOnly().and(remoteRepository -> repositoryIds.contains(remoteRepository.getId()));
     }
 
     /**

--- a/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNodeConfig.java
+++ b/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNodeConfig.java
@@ -20,7 +20,11 @@ public class JGroupsNodeConfig {
         String groupSuffix = "@n/a";
         if (config.mimirVersion().isPresent()) {
             String version = config.mimirVersion().orElseThrow();
-            groupSuffix = "@" + version.substring(0, version.lastIndexOf('.'));
+            if (version.endsWith("-SNAPSHOT")) {
+                groupSuffix = version;
+            } else {
+                groupSuffix = "@" + version.substring(0, version.lastIndexOf('.'));
+            }
         }
 
         boolean enabled = true;


### PR DESCRIPTION
So far Mimir handled Central only, on purpose. In version 0.6.0 there was a bold move, that is undone more properly: that version started handling all release-direct repositories.

Instead, provide config to allow users to tune which repo to cache. **By default Mimir is back to cache Central only**.

Also, contains a small bugfix: SNAPSHOT Mimir daemons should not join the cluster of RELEASE Mimir daemons, as if developer is using Mimir locally it usually leads to IT failures.