### PR TITLE
Global network hint

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/Config.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/Config.java
@@ -25,6 +25,33 @@ import java.util.Properties;
  * Simple Mimir configuration.
  */
 public interface Config {
+    String NAME = "mimir";
+
+    String CONF_PREFIX = NAME + ".";
+
+    /**
+     * Mimir "local host hint": on hosts where there is running Docker, Tailscale etc. it may be impossible to "figure out"
+     * which interface and which address correspond to LAN address, if any. Hence, one can give Mimir a "hint" that is
+     * globally applied at Mimir level (like publishers or LAN sharing is). Accepted hints are:
+     *
+     * <ul>
+     *     <li><code>match-interface:value</code></li>
+     *     <li><code>match-address:value</code></li>
+     * </ul>
+     *
+     * In both cases "value" may end with "*" (asterisk). If no asterisk, value equality is checked, if it ends with
+     * asterisk, then "starts with value" is checked.
+     * Examples:
+     *
+     * <ul>
+     *     <li><code>match-interface:enp*</code> means "use interface whose name starts with enp"</li>
+     *     <li><code>match-address:192.168.1.10</code> means "use address that equals to 192.168.1.10"</li>
+     * </ul>
+     *
+     * These hints may still produce wrong address selection, so one should check logs to ensure about them.
+     */
+    String CONF_LOCAL_HOST_HINT = CONF_PREFIX + "localHostHint";
+
     boolean enabled();
 
     Optional<String> mimirVersion();
@@ -38,6 +65,10 @@ public interface Config {
     Map<String, String> systemProperties();
 
     Map<String, String> effectiveProperties();
+
+    default Optional<String> localHostHint() {
+        return Optional.ofNullable(effectiveProperties().get(CONF_LOCAL_HOST_HINT));
+    }
 
     default Builder toBuilder() {
         return new Builder(

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/publisher/PublisherConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/publisher/PublisherConfig.java
@@ -17,7 +17,8 @@ public class PublisherConfig {
     public static PublisherConfig with(Config config) throws IOException {
         requireNonNull(config, "config");
 
-        String hostAddress = Utils.getLocalHost().getHostAddress();
+        String hostAddress =
+                Utils.getLocalHost(config.localHostHint().orElse(null)).getHostAddress();
         int hostPort = 0;
 
         if (config.effectiveProperties().containsKey("mimir.publisher.hostAddress")) {

--- a/node/file/src/main/java/eu/maveniverse/maven/mimir/node/file/FileNode.java
+++ b/node/file/src/main/java/eu/maveniverse/maven/mimir/node/file/FileNode.java
@@ -183,11 +183,17 @@ public final class FileNode extends NodeSupport<FileEntry> implements SystemNode
     protected void doClose() throws IOException {
         try {
             if (exclusiveAccess && cachePurge) {
-                logger.info("Purging caches... Not implemented yet ;)");
+                purgeCaches();
             }
         } finally {
             directoryLocker.unlockDirectory(basedir);
         }
+    }
+
+    private void purgeCaches() {
+        logger.info("Purging caches...");
+        // purge all unused entries (+ apply some window from "now" to +time)
+        // all - touched - not in timeframe (if not "now") -> delete?
     }
 
     private void storeMetadata(Path file, Map<String, String> metadata) throws IOException {

--- a/node/minio/src/main/java/eu/maveniverse/maven/mimir/node/minio/MinioNodeConfig.java
+++ b/node/minio/src/main/java/eu/maveniverse/maven/mimir/node/minio/MinioNodeConfig.java
@@ -25,6 +25,8 @@ public class MinioNodeConfig {
         String secretKey = "minioadmin";
         List<String> checksumAlgorithms = Arrays.asList("SHA-1", "SHA-512");
         String keyResolver = SimpleKeyResolverFactory.NAME;
+        boolean exclusiveAccess = false;
+        boolean cachePurge = false;
 
         if (config.effectiveProperties().containsKey("mimir.minio.endpoint")) {
             endpoint = config.effectiveProperties().get("mimir.minio.endpoint");
@@ -45,7 +47,14 @@ public class MinioNodeConfig {
         if (config.effectiveProperties().containsKey("mimir.minio.keyResolver")) {
             keyResolver = config.effectiveProperties().get("mimir.minio.keyResolver");
         }
-        return new MinioNodeConfig(endpoint, accessKey, secretKey, checksumAlgorithms, keyResolver);
+        if (config.effectiveProperties().containsKey("mimir.minio.exclusiveAccess")) {
+            exclusiveAccess = Boolean.parseBoolean(config.effectiveProperties().get("mimir.minio.exclusiveAccess"));
+        }
+        if (config.effectiveProperties().containsKey("mimir.minio.cachePurge")) {
+            cachePurge = Boolean.parseBoolean(config.effectiveProperties().get("mimir.minio.cachePurge"));
+        }
+        return new MinioNodeConfig(
+                endpoint, accessKey, secretKey, checksumAlgorithms, keyResolver, exclusiveAccess, cachePurge);
     }
 
     public static final String NAME = "minio";
@@ -55,14 +64,24 @@ public class MinioNodeConfig {
     private final String secretKey;
     private final List<String> checksumAlgorithms;
     private final String keyResolver;
+    private final boolean exclusiveAccess;
+    private final boolean cachePurge;
 
     private MinioNodeConfig(
-            String endpoint, String accessKey, String secretKey, List<String> checksumAlgorithms, String keyResolver) {
+            String endpoint,
+            String accessKey,
+            String secretKey,
+            List<String> checksumAlgorithms,
+            String keyResolver,
+            boolean exclusiveAccess,
+            boolean cachePurge) {
         this.endpoint = endpoint;
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.checksumAlgorithms = checksumAlgorithms;
         this.keyResolver = keyResolver;
+        this.exclusiveAccess = exclusiveAccess;
+        this.cachePurge = cachePurge;
     }
 
     public String endpoint() {
@@ -83,5 +102,13 @@ public class MinioNodeConfig {
 
     public String keyResolver() {
         return keyResolver;
+    }
+
+    public boolean exclusiveAccess() {
+        return exclusiveAccess;
+    }
+
+    public boolean cachePurge() {
+        return cachePurge;
     }
 }

--- a/node/minio/src/main/java/eu/maveniverse/maven/mimir/node/minio/MinioNodeFactory.java
+++ b/node/minio/src/main/java/eu/maveniverse/maven/mimir/node/minio/MinioNodeFactory.java
@@ -53,7 +53,13 @@ public class MinioNodeFactory implements SystemNodeFactory {
         }
         MinioClient minioClient = createMinioClient(minioNodeConfig);
         return new MinioNode(
-                minioNodeConfig, minioClient, keyResolver, minioNodeConfig.checksumAlgorithms(), checksumFactories);
+                minioNodeConfig,
+                minioClient,
+                minioNodeConfig.exclusiveAccess(),
+                minioNodeConfig.cachePurge(),
+                keyResolver,
+                minioNodeConfig.checksumAlgorithms(),
+                checksumFactories);
     }
 
     private MinioClient createMinioClient(MinioNodeConfig minioNodeConfig) {


### PR DESCRIPTION
Mimir utilize multiple network accessing elements
(JGroups, Publishers), that on more complex setups with multiple interfaces and addresses may get
confused and bind to different addresses even.

Before it was possible to "hint" JGroups, but
Publisher may choose different address.

Now there is "global" hint, that is applied to
all networking elements, and ensures everything
is aligned -- bound to same interface and address.

Now it is enough to state in `~/.mimir/daemon.properties` this:
```
mimir.localHostHint=match-address\:192.168.1.*
```

And all of Mimir (JGroups, Publishers) will bind to this
address.