### PR TITLE
Daemon startup fix

### DIFF
--- a/daemon-protocol/src/main/java/eu/maveniverse/maven/mimir/daemon/protocol/Handle.java
+++ b/daemon-protocol/src/main/java/eu/maveniverse/maven/mimir/daemon/protocol/Handle.java
@@ -20,6 +20,7 @@ import java.nio.channels.ByteChannel;
 import java.nio.channels.Channels;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -65,7 +66,11 @@ public class Handle implements Closeable {
             @Override
             public void close() throws IOException {
                 if (closed.compareAndSet(false, true)) {
-                    serverSocketChannel.close();
+                    try {
+                        serverSocketChannel.close();
+                    } finally {
+                        Files.deleteIfExists(domainSocketPath);
+                    }
                 }
             }
         };

--- a/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
+++ b/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
@@ -75,6 +75,7 @@ public class Daemon extends CloseableConfigSupport<DaemonConfig> implements Clos
             Runtime.getRuntime().addShutdownHook(new Thread(daemon::shutdown));
         } catch (Exception e) {
             e.printStackTrace(System.out);
+            System.exit(1);
         }
     }
 

--- a/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/DaemonConfig.java
+++ b/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/DaemonConfig.java
@@ -17,6 +17,7 @@ public class DaemonConfig {
     public static DaemonConfig with(Config config) {
         requireNonNull(config, "config");
 
+        Path daemonBasedir = config.basedir().resolve("daemon");
         Path socketPath = config.basedir().resolve(Handle.DEFAULT_SOCKET_PATH);
         String systemNode = "file";
 
@@ -27,15 +28,27 @@ public class DaemonConfig {
         if (config.effectiveProperties().containsKey("mimir.daemon.systemNode")) {
             systemNode = config.effectiveProperties().get("mimir.daemon.systemNode");
         }
-        return new DaemonConfig(socketPath, systemNode);
+        return new DaemonConfig(config, daemonBasedir, socketPath, systemNode);
     }
 
+    private final Config config;
+    private final Path daemonBasedir;
     private final Path socketPath;
     private final String systemNode;
 
-    private DaemonConfig(Path socketPath, String systemNode) {
+    private DaemonConfig(Config config, Path daemonBasedir, Path socketPath, String systemNode) {
+        this.config = requireNonNull(config);
+        this.daemonBasedir = requireNonNull(daemonBasedir);
         this.socketPath = requireNonNull(socketPath);
         this.systemNode = requireNonNull(systemNode);
+    }
+
+    public Config config() {
+        return config;
+    }
+
+    public Path daemonBasedir() {
+        return daemonBasedir;
     }
 
     public Path socketPath() {

--- a/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
@@ -12,7 +12,6 @@ import eu.maveniverse.maven.mimir.shared.Config;
 import eu.maveniverse.maven.mimir.shared.SessionFactory;
 import eu.maveniverse.maven.shared.core.fs.FileUtils;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import javax.inject.Inject;
@@ -92,8 +91,7 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
             logger.debug("Not resolving Mimir daemon; autostart not enabled or version not detected");
             return;
         }
-        Path daemonJarPath = config.basedir().resolve(daemonConfig.daemonJarName());
-        if (!Files.exists(daemonJarPath)) {
+        if (!Files.exists(daemonConfig.daemonJar())) {
             try {
                 logger.info(
                         "Resolving Mimir daemon version {}",
@@ -101,8 +99,8 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
                 ArtifactRequest artifactRequest =
                         new ArtifactRequest(new DefaultArtifact(daemonConfig.daemonGav()), remoteRepositories, "mimir");
                 ArtifactResult artifactResult = repositorySystem.resolveArtifact(session, artifactRequest);
-                Files.createDirectories(daemonJarPath.getParent());
-                FileUtils.copyOrLink(artifactResult.getArtifact().getFile().toPath(), daemonJarPath);
+                Files.createDirectories(daemonConfig.daemonJar().getParent());
+                FileUtils.copyOrLink(artifactResult.getArtifact().getFile().toPath(), daemonConfig.daemonJar());
             } catch (Exception e) {
                 logger.warn("Failed to resolve daemon: {}", e.getMessage());
             }

--- a/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonConfig.java
+++ b/node/daemon/src/main/java/eu/maveniverse/maven/mimir/node/daemon/DaemonConfig.java
@@ -21,6 +21,7 @@ public class DaemonConfig {
         final boolean mimirVersionPresent = config.mimirVersion().isPresent();
         final String mimirVersion = config.mimirVersion().orElse("UNKNOWN");
 
+        Path daemonBasedir = config.basedir().resolve("daemon");
         Path socketPath = config.basedir().resolve(Handle.DEFAULT_SOCKET_PATH);
         Path daemonJavaHome = Path.of(config.effectiveProperties()
                 .getOrDefault(
@@ -29,8 +30,8 @@ public class DaemonConfig {
         boolean autostart = mimirVersionPresent;
         Duration autostartDuration = Duration.ofMinutes(1);
         boolean autostop = false;
-        String daemonJarName = "daemon-" + mimirVersion + ".jar";
-        String daemonLogName = "daemon-" + mimirVersion + ".log";
+        Path daemonJar = config.basedir().resolve("daemon-" + mimirVersion + ".jar");
+        Path daemonLog = config.basedir().resolve("daemon-" + mimirVersion + ".log");
         String daemonGav = "eu.maveniverse.maven.mimir:daemon:jar:daemon:" + mimirVersion;
         boolean passOnBasedir = false;
         boolean debug = false;
@@ -51,11 +52,11 @@ public class DaemonConfig {
         if (config.effectiveProperties().containsKey("mimir.daemon.autostop")) {
             autostop = Boolean.parseBoolean(config.effectiveProperties().get("mimir.daemon.autostop"));
         }
-        if (config.effectiveProperties().containsKey("mimir.daemon.daemonJarName")) {
-            daemonJarName = config.effectiveProperties().get("mimir.daemon.daemonJarName");
+        if (config.effectiveProperties().containsKey("mimir.daemon.daemonJar")) {
+            daemonJar = config.basedir().resolve(config.effectiveProperties().get("mimir.daemon.daemonJar"));
         }
-        if (config.effectiveProperties().containsKey("mimir.daemon.daemonLogName")) {
-            daemonLogName = config.effectiveProperties().get("mimir.daemon.daemonLogName");
+        if (config.effectiveProperties().containsKey("mimir.daemon.daemonLog")) {
+            daemonLog = config.basedir().resolve(config.effectiveProperties().get("mimir.daemon.daemonLog"));
         }
         if (config.effectiveProperties().containsKey("mimir.daemon.daemonGav")) {
             daemonGav = config.effectiveProperties().get("mimir.daemon.daemonGav");
@@ -67,14 +68,16 @@ public class DaemonConfig {
             debug = Boolean.parseBoolean(config.effectiveProperties().get("mimir.daemon.debug"));
         }
         return new DaemonConfig(
+                config,
+                daemonBasedir,
                 socketPath,
                 daemonJavaHome,
                 autoupdate,
                 autostart,
                 autostartDuration,
                 autostop,
-                daemonJarName,
-                daemonLogName,
+                daemonJar,
+                daemonLog,
                 daemonGav,
                 passOnBasedir,
                 debug);
@@ -82,41 +85,55 @@ public class DaemonConfig {
 
     public static final String NAME = "daemon";
 
+    private final Config config;
+    private final Path daemonBasedir;
     private final Path socketPath;
     private final Path daemonJavaHome;
     private final boolean autoupdate;
     private final boolean autostart;
     private final Duration autostartDuration;
     private final boolean autostop;
-    private final String daemonJarName;
-    private final String daemonLogName;
+    private final Path daemonJar;
+    private final Path daemonLog;
     private final String daemonGav;
     private final boolean passOnBasedir;
     private final boolean debug;
 
     private DaemonConfig(
+            Config config,
+            Path daemonBasedir,
             Path socketPath,
             Path daemonJavaHome,
             boolean autoupdate,
             boolean autostart,
             Duration autostartDuration,
             boolean autostop,
-            String daemonJarName,
-            String daemonLogName,
+            Path daemonJar,
+            Path daemonLog,
             String daemonGav,
             boolean passOnBasedir,
             boolean debug) {
+        this.config = requireNonNull(config);
+        this.daemonBasedir = requireNonNull(daemonBasedir);
         this.socketPath = requireNonNull(socketPath);
         this.daemonJavaHome = requireNonNull(daemonJavaHome);
         this.autoupdate = autoupdate;
         this.autostart = autostart;
         this.autostartDuration = requireNonNull(autostartDuration);
         this.autostop = autostop;
-        this.daemonJarName = requireNonNull(daemonJarName);
-        this.daemonLogName = requireNonNull(daemonLogName);
+        this.daemonJar = requireNonNull(daemonJar);
+        this.daemonLog = requireNonNull(daemonLog);
         this.daemonGav = requireNonNull(daemonGav);
         this.passOnBasedir = passOnBasedir;
         this.debug = debug;
+    }
+
+    public Config config() {
+        return config;
+    }
+
+    public Path daemonBasedir() {
+        return daemonBasedir;
     }
 
     public Path socketPath() {
@@ -143,12 +160,12 @@ public class DaemonConfig {
         return autostop;
     }
 
-    public String daemonJarName() {
-        return daemonJarName;
+    public Path daemonJar() {
+        return daemonJar;
     }
 
-    public String daemonLogName() {
-        return daemonLogName;
+    public Path daemonLog() {
+        return daemonLog;
     }
 
     public String daemonGav() {

--- a/node/file/src/main/java/eu/maveniverse/maven/mimir/node/file/FileNodeFactory.java
+++ b/node/file/src/main/java/eu/maveniverse/maven/mimir/node/file/FileNodeFactory.java
@@ -26,16 +26,13 @@ import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
 public final class FileNodeFactory implements SystemNodeFactory {
     private final Map<String, KeyResolverFactory> keyResolverFactories;
     private final Map<String, ChecksumAlgorithmFactory> checksumFactories;
-    private final DirectoryLocker directoryLocker;
 
     @Inject
     public FileNodeFactory(
             Map<String, KeyResolverFactory> keyResolverFactories,
-            Map<String, ChecksumAlgorithmFactory> checksumFactories,
-            DirectoryLocker directoryLocker) {
+            Map<String, ChecksumAlgorithmFactory> checksumFactories) {
         this.keyResolverFactories = requireNonNull(keyResolverFactories, "keyResolverFactories");
         this.checksumFactories = requireNonNull(checksumFactories, "checksumFactories");
-        this.directoryLocker = requireNonNull(directoryLocker, "directoryLocker");
     }
 
     @Override
@@ -64,6 +61,6 @@ public final class FileNodeFactory implements SystemNodeFactory {
                 keyResolver,
                 fileNodeConfig.checksumAlgorithms(),
                 checksumFactories,
-                directoryLocker);
+                DirectoryLocker.INSTANCE);
     }
 }

--- a/node/file/src/test/java/eu/maveniverse/maven/mimir/node/file/FileNodeTest.java
+++ b/node/file/src/test/java/eu/maveniverse/maven/mimir/node/file/FileNodeTest.java
@@ -11,7 +11,6 @@ import eu.maveniverse.maven.mimir.shared.impl.naming.SimpleKeyMapperFactory;
 import eu.maveniverse.maven.mimir.shared.impl.naming.SimpleKeyResolverFactory;
 import eu.maveniverse.maven.mimir.shared.naming.KeyMapper;
 import eu.maveniverse.maven.mimir.shared.node.SystemEntry;
-import eu.maveniverse.maven.shared.core.fs.DirectoryLocker;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -45,8 +44,7 @@ public class FileNodeTest {
                                 Sha1ChecksumAlgorithmFactory.NAME,
                                 new Sha1ChecksumAlgorithmFactory(),
                                 Sha512ChecksumAlgorithmFactory.NAME,
-                                new Sha512ChecksumAlgorithmFactory()),
-                        new DirectoryLocker())
+                                new Sha512ChecksumAlgorithmFactory()))
                 .createNode(config)) {
             Optional<FileEntry> entry = fileNode.locate(keyMapper.apply(central, junit));
             assertFalse(entry.isPresent());
@@ -88,8 +86,7 @@ public class FileNodeTest {
                                 Sha1ChecksumAlgorithmFactory.NAME,
                                 new Sha1ChecksumAlgorithmFactory(),
                                 Sha512ChecksumAlgorithmFactory.NAME,
-                                new Sha512ChecksumAlgorithmFactory()),
-                        new DirectoryLocker())
+                                new Sha512ChecksumAlgorithmFactory()))
                 .createNode(config)) {
             Optional<FileEntry> entry = fileNode.locate(keyMapper.apply(central, junit));
             assertFalse(entry.isPresent());
@@ -131,8 +128,7 @@ public class FileNodeTest {
                         Sha1ChecksumAlgorithmFactory.NAME,
                         new Sha1ChecksumAlgorithmFactory(),
                         Sha512ChecksumAlgorithmFactory.NAME,
-                        new Sha512ChecksumAlgorithmFactory()),
-                new DirectoryLocker());
+                        new Sha512ChecksumAlgorithmFactory()));
         try (FileNode fileNode1 = fileNodeFactory.createNode(config);
                 FileNode fileNode2 = fileNodeFactory.createNode(config)) {
             // should be ok
@@ -151,8 +147,7 @@ public class FileNodeTest {
                         Sha1ChecksumAlgorithmFactory.NAME,
                         new Sha1ChecksumAlgorithmFactory(),
                         Sha512ChecksumAlgorithmFactory.NAME,
-                        new Sha512ChecksumAlgorithmFactory()),
-                new DirectoryLocker());
+                        new Sha512ChecksumAlgorithmFactory()));
         try (FileNode fileNode = fileNodeFactory.createNode(config)) {
             assertThrows(IOException.class, () -> fileNodeFactory.createNode(config));
         }

--- a/node/jgroups/src/test/java/eu/maveniverse/maven/mimir/jgroups/JGroupsNodeTest.java
+++ b/node/jgroups/src/test/java/eu/maveniverse/maven/mimir/jgroups/JGroupsNodeTest.java
@@ -52,7 +52,7 @@ public class JGroupsNodeTest {
                 new SimpleKeyResolverFactory().createKeyResolver(config),
                 List.of(Sha1ChecksumAlgorithmFactory.NAME),
                 Map.of(Sha1ChecksumAlgorithmFactory.NAME, new Sha1ChecksumAlgorithmFactory()),
-                new DirectoryLocker());
+                DirectoryLocker.INSTANCE);
         FileNodeConfig configTwo = FileNodeConfig.of(
                 two, true, Collections.singletonList("SHA-1"), SimpleKeyResolverFactory.NAME, false, false);
         FileNode nodeTwo = new FileNode(
@@ -63,7 +63,7 @@ public class JGroupsNodeTest {
                 new SimpleKeyResolverFactory().createKeyResolver(config),
                 List.of(Sha1ChecksumAlgorithmFactory.NAME),
                 Map.of(Sha1ChecksumAlgorithmFactory.NAME, new Sha1ChecksumAlgorithmFactory()),
-                new DirectoryLocker());
+                DirectoryLocker.INSTANCE);
 
         String testGroup = UUID.randomUUID().toString();
         JChannel channelOne = new JChannel("udp-new.xml")

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <requireRuntimeMavenVersion.range>[3.9,)</requireRuntimeMavenVersion.range>
 
     <!-- Dependency versions -->
-    <version.maveniverseShared>0.1.4</version.maveniverseShared>
+    <version.maveniverseShared>0.1.5</version.maveniverseShared>
     <version.maven>3.9.9</version.maven>
     <version.resolver>1.9.23</version.resolver>
     <version.slf4j>2.0.17</version.slf4j>


### PR DESCRIPTION
Originally, `DaemonNode` (running in Maven JVM) checked for presence of UDS socket file, and if absent, tried to start up daemon. If file present, it assumed daemon is present. Daemon OTOH was coded to create socket on start, and delete socket on (clean) exit, but alas, turned out that on some OS-es when shutdown/restart happens, it kills processes, so daemon process was killed: it left "dead" UDS socket file in place. In these cases `DaemonNode` falsely assumed daemon is alive, and failed.

Now, daemon has a directory `$basedir/daemon` that daemon _exclusively locks_ when runs. This implies, that if anyone else _can lock it_, daemon does not run (irrelevant is UDS socket file present or not). Simpler change happened on daemon side, it merely locks the new directory and unlocks it on exit (and some other cleanup happened). `DaemonNodeFactory` got more serious logic to start up daemon, even support for competing processes trying to start up daemon.

Also apply update https://github.com/maveniverse/maven-shared/releases/tag/release-0.1.5

Fixes #86 