### PR TITLE
Stick with Maven3 for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,12 +194,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>4.0.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-xml</artifactId>
-        <version>3.0.2</version>
+        <version>3.5.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
So do not mix in p-u 4.x and pull p-x etc. 
Just downgrade to "old" p-u 3.5.1