### PR TITLE
Rework configuration, add sessions

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionFactoryImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionFactoryImpl.java
@@ -73,7 +73,7 @@ public final class SessionFactoryImpl extends ComponentSupport implements Sessio
         }
 
         if (logger.isDebugEnabled()) {
-            logger.debug("Mimir {} session created", config.mimirVersion().orElse("UNKNOWN"));
+            logger.debug("Mimir {} session created", config.mimirVersion());
             logger.debug("  Enabled: {}", config.enabled());
             logger.debug("  Properties: {}", config.basedir().resolve(config.propertiesPath()));
             logger.debug("  Key mapper: {}", keyMapper.getClass().getSimpleName());

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionFactoryImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionFactoryImpl.java
@@ -75,6 +75,7 @@ public final class SessionFactoryImpl extends ComponentSupport implements Sessio
         if (logger.isDebugEnabled()) {
             logger.debug("Mimir {} session created", config.mimirVersion());
             logger.debug("  Enabled: {}", config.enabled());
+            logger.debug("  Basedir: {}", config.basedir());
             logger.debug("  Properties: {}", config.basedir().resolve(config.propertiesPath()));
             logger.debug("  Key mapper: {}", keyMapper.getClass().getSimpleName());
             logger.debug("  Local Node: {}", localNode);

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
@@ -57,9 +57,9 @@ public final class SessionImpl extends CloseableConfigSupport<SessionConfig> imp
         this.storedToCache = new ConcurrentHashMap<>();
 
         if (sessionConfig.enabled()) {
-            logger.info("Mimir session created with {}", localNode);
+            logger.info("Mimir {} session created with {}", config().mimirVersion(), localNode);
         } else {
-            logger.info("Mimir is disabled");
+            logger.info("Mimir {} is disabled", config().mimirVersion());
         }
     }
 

--- a/daemon-protocol/src/main/java/eu/maveniverse/maven/mimir/daemon/protocol/Session.java
+++ b/daemon-protocol/src/main/java/eu/maveniverse/maven/mimir/daemon/protocol/Session.java
@@ -20,4 +20,8 @@ public final class Session {
 
     // session
     public static final String SESSION_ID = "sessionId";
+
+    // lrm
+    public static final String LRM_PREFIX = "lrm.";
+    public static final String LRM_PATH = LRM_PREFIX + "path";
 }

--- a/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/DaemonConfig.java
+++ b/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/DaemonConfig.java
@@ -11,35 +11,36 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.mimir.daemon.protocol.Handle;
 import eu.maveniverse.maven.mimir.shared.SessionConfig;
+import eu.maveniverse.maven.shared.core.fs.FileUtils;
 import java.nio.file.Path;
 
 public class DaemonConfig {
     public static DaemonConfig with(SessionConfig sessionConfig) {
         requireNonNull(sessionConfig, "config");
 
-        Path daemonBasedir = sessionConfig.basedir().resolve("daemon");
+        Path daemonLockDir = sessionConfig.basedir().resolve("daemon");
         Path socketPath = sessionConfig.basedir().resolve(Handle.DEFAULT_SOCKET_PATH);
         String systemNode = "file";
 
         if (sessionConfig.effectiveProperties().containsKey("mimir.daemon.socketPath")) {
-            socketPath = SessionConfig.getCanonicalPath(sessionConfig
+            socketPath = FileUtils.canonicalPath(sessionConfig
                     .basedir()
                     .resolve(sessionConfig.effectiveProperties().get("mimir.daemon.socketPath")));
         }
         if (sessionConfig.effectiveProperties().containsKey("mimir.daemon.systemNode")) {
             systemNode = sessionConfig.effectiveProperties().get("mimir.daemon.systemNode");
         }
-        return new DaemonConfig(sessionConfig, daemonBasedir, socketPath, systemNode);
+        return new DaemonConfig(sessionConfig, daemonLockDir, socketPath, systemNode);
     }
 
     private final SessionConfig sessionConfig;
-    private final Path daemonBasedir;
+    private final Path daemonLockDir;
     private final Path socketPath;
     private final String systemNode;
 
-    private DaemonConfig(SessionConfig sessionConfig, Path daemonBasedir, Path socketPath, String systemNode) {
+    private DaemonConfig(SessionConfig sessionConfig, Path daemonLockDir, Path socketPath, String systemNode) {
         this.sessionConfig = requireNonNull(sessionConfig);
-        this.daemonBasedir = requireNonNull(daemonBasedir);
+        this.daemonLockDir = requireNonNull(daemonLockDir);
         this.socketPath = requireNonNull(socketPath);
         this.systemNode = requireNonNull(systemNode);
     }
@@ -48,8 +49,8 @@ public class DaemonConfig {
         return sessionConfig;
     }
 
-    public Path daemonBasedir() {
-        return daemonBasedir;
+    public Path daemonLockDir() {
+        return daemonLockDir;
     }
 
     public Path socketPath() {

--- a/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
@@ -62,6 +62,7 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
                     SessionConfig sessionConfig = SessionConfig.defaults()
                             .userProperties(repoSession.getUserProperties())
                             .systemProperties(repoSession.getSystemProperties())
+                            .repositorySystemSession(repoSession)
                             .build();
                     if (sessionConfig.enabled()) {
                         List<RemoteRepository> remoteRepositories = RepositoryUtils.toRepos(
@@ -111,11 +112,7 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
         }
         if (!Files.exists(daemonConfig.daemonJar())) {
             try {
-                logger.info(
-                        "Resolving Mimir daemon version {}",
-                        sessionConfig
-                                .mimirVersion()
-                                .orElseThrow(() -> new IllegalStateException("Value is not present")));
+                logger.info("Resolving Mimir daemon version {}", sessionConfig.mimirVersion());
                 ArtifactRequest artifactRequest =
                         new ArtifactRequest(new DefaultArtifact(daemonConfig.daemonGav()), remoteRepositories, "mimir");
                 ArtifactResult artifactResult = repositorySystem.resolveArtifact(session, artifactRequest);
@@ -139,8 +136,7 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
             return;
         }
         try {
-            String mimirVersion =
-                    sessionConfig.mimirVersion().orElseThrow(() -> new IllegalStateException("Value is not present"));
+            String mimirVersion = sessionConfig.mimirVersion();
             logger.debug("Checking for Mimir updates...");
             VersionRangeRequest versionRangeRequest = new VersionRangeRequest(
                     new DefaultArtifact(daemonConfig.daemonGav()).setVersion("[" + mimirVersion + ",)"),

--- a/it/extension-its/src/it/daemon-basedir/.mvn/extensions.xml
+++ b/it/extension-its/src/it/daemon-basedir/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.mimir</groupId>
+        <artifactId>extension</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension-its/src/it/daemon-basedir/README.md
+++ b/it/extension-its/src/it/daemon-basedir/README.md
@@ -1,0 +1,10 @@
+# Daemon Basedir
+
+This test primes Mimir cache in 1st pass, and then in 2nd pass makes use of it. 
+Assertions are done against Mimir stats.
+
+The trick is first run "awakes" daemon, and then second run continues to use
+it and finally "kills" it.
+
+This test is prove we can easily "relocate" Mimir daemon basedir irrelevant of
+actual "client side" of Mimir basedir.

--- a/it/extension-its/src/it/daemon-basedir/invoker.properties
+++ b/it/extension-its/src/it/daemon-basedir/invoker.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# 1st: mimir empty && local repo empty
+invoker.goals.1 = -V -e clean install -l first.log -Dmimir.basedir=mimir1 -Dmimir.daemon.passOnBasedir -Dmaven.repo.local=first -Dmaven.repo.local.tail=../../it-repo-tail
+# 2nd: mimir primed && local repo empty
+invoker.goals.2 = -V -e clean install -l second.log -Dmimir.daemon.autostop -Dmimir.basedir=mimir2 -Dmaven.repo.local=second -Dmaven.repo.local.tail=../../it-repo-tail

--- a/it/extension-its/src/it/daemon-basedir/mimir1/daemon.properties
+++ b/it/extension-its/src/it/daemon-basedir/mimir1/daemon.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+mimir.jgroups.enabled=false

--- a/it/extension-its/src/it/daemon-basedir/mimir1/mimir.properties
+++ b/it/extension-its/src/it/daemon-basedir/mimir1/mimir.properties
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+mimir.daemon.debug=true

--- a/it/extension-its/src/it/daemon-basedir/mimir2/mimir.properties
+++ b/it/extension-its/src/it/daemon-basedir/mimir2/mimir.properties
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+mimir.daemon.basedir=../mimir1
+mimir.daemon.autoupdate=false
+mimir.daemon.autostart=false

--- a/it/extension-its/src/it/daemon-basedir/pom.xml
+++ b/it/extension-its/src/it/daemon-basedir/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.mimir.it.no-http-traffic</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0.0</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension-its/src/it/daemon-basedir/verify.groovy
+++ b/it/extension-its/src/it/daemon-basedir/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+String build = buildLog.text
+
+File firstLog = new File( basedir, 'first.log' )
+assert firstLog.exists() : build
+String first = firstLog.text
+
+File secondLog = new File( basedir, 'second.log' )
+assert secondLog.exists() : first
+String second = secondLog.text
+
+// Lets make strict assertion
+// Also, consider Maven 3 vs 4 diff: they resolve differently; do not assert counts
+
+// first run: both were empty: retrieved==0 cached!=0
+assert first.contains('[INFO] Mimir session closed')
+assert first.contains('RETRIEVED=0')
+assert first.contains('CACHED=') && !first.contains('CACHED=0')
+
+// second run: mimir is primed, local repo is empty: retrieved!=0 cached==0
+assert second.contains('[INFO] Mimir session closed')
+assert second.contains('RETRIEVED=') && !second.contains('RETRIEVED=0')
+assert second.contains('CACHED=0')

--- a/node/file/src/main/java/eu/maveniverse/maven/mimir/node/file/FileNodeConfig.java
+++ b/node/file/src/main/java/eu/maveniverse/maven/mimir/node/file/FileNodeConfig.java
@@ -12,6 +12,7 @@ import static java.util.stream.Collectors.toList;
 
 import eu.maveniverse.maven.mimir.shared.SessionConfig;
 import eu.maveniverse.maven.mimir.shared.impl.naming.SimpleKeyResolverFactory;
+import eu.maveniverse.maven.shared.core.fs.FileUtils;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +29,7 @@ public final class FileNodeConfig {
         boolean cachePurge = false;
 
         if (sessionConfig.effectiveProperties().containsKey("mimir.file.basedir")) {
-            basedir = SessionConfig.getCanonicalPath(
+            basedir = FileUtils.canonicalPath(
                     Path.of(sessionConfig.effectiveProperties().get("mimir.file.basedir")));
         }
         if (sessionConfig.effectiveProperties().containsKey("mimir.file.mayLink")) {
@@ -65,7 +66,7 @@ public final class FileNodeConfig {
             boolean exclusiveAccess,
             boolean cachePurge) {
         return new FileNodeConfig(
-                SessionConfig.getCanonicalPath(basedir),
+                FileUtils.canonicalPath(basedir),
                 mayLink,
                 checksumAlgorithms,
                 keyResolver,

--- a/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNodeConfig.java
+++ b/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNodeConfig.java
@@ -18,8 +18,8 @@ public class JGroupsNodeConfig {
         requireNonNull(sessionConfig, "config");
 
         String groupSuffix = "@n/a";
-        if (sessionConfig.mimirVersion().isPresent()) {
-            String version = sessionConfig.mimirVersion().orElseThrow();
+        if (!SessionConfig.UNKNOWN_VERSION.equals(sessionConfig.mimirVersion())) {
+            String version = sessionConfig.mimirVersion();
             if (version.endsWith("-SNAPSHOT")) {
                 groupSuffix = "@" + version;
             } else {

--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,10 @@
     <requireRuntimeMavenVersion.range>[3.9,)</requireRuntimeMavenVersion.range>
 
     <!-- Dependency versions -->
-    <version.maveniverseShared>0.1.6</version.maveniverseShared>
+    <version.maveniverseShared>0.1.8</version.maveniverseShared>
     <version.maven>3.9.9</version.maven>
     <version.resolver>1.9.23</version.resolver>
-    <version.slf4j>2.0.17</version.slf4j>
+    <version.slf4j>1.7.36</version.slf4j>
     <version.testcontainers>1.21.1</version.testcontainers>
   </properties>
 


### PR DESCRIPTION
Make it proper immutable and pre-calculated. Fix issues regarding daemon basedir, and make it possible to make mimir client use alt daemon: now `mimir.properties` may contain property `mimir.daemon.basedir` that may point to some alt location.

Added IT `daemon-basedir` where this is tested, first run starts and populates daemon, and second run with own mimir basedir reuses daemon started in first run continuing running in previous basedir.

Aside of this daemon got session support, where daemon stores "sessions" of connected clients.

Also many minor cleanups happened regarding configuration handling.

Fixes #103