### PR TITLE
Enabled fix: when Mimir disabled it should remain fully dormant

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/MimirUtils.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/MimirUtils.java
@@ -22,7 +22,9 @@ public final class MimirUtils {
         Session session = (Session) repositorySystemSession.getData().get(Session.class);
         if (session == null) {
             session = sessionFactory.get();
-            repositorySystemSession.getData().set(Session.class, session);
+            if (session != null) {
+                repositorySystemSession.getData().set(Session.class, session);
+            }
         }
         return session;
     }

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
@@ -56,11 +56,7 @@ public final class SessionImpl extends CloseableConfigSupport<SessionConfig> imp
         this.retrievedFromCache = new ConcurrentHashMap<>();
         this.storedToCache = new ConcurrentHashMap<>();
 
-        if (sessionConfig.enabled()) {
-            logger.info("Mimir {} session created with {}", config().mimirVersion(), localNode);
-        } else {
-            logger.info("Mimir {} is disabled", config().mimirVersion());
-        }
+        logger.info("Mimir {} session created with {}", config().mimirVersion(), localNode);
     }
 
     @Override

--- a/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirArtifactResolverPostProcessor.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirArtifactResolverPostProcessor.java
@@ -44,8 +44,7 @@ public class MimirArtifactResolverPostProcessor extends ComponentSupport impleme
         for (ArtifactResult artifactResult : artifactResults) {
             if (artifactResult.getRepository() instanceof RemoteRepository remoteRepository) {
                 Optional<Session> sessionOptional = MimirUtils.mayGetSession(session);
-                if (sessionOptional.isPresent()
-                        && sessionOptional.orElseThrow().config().enabled()) {
+                if (sessionOptional.isPresent()) {
                     Session ms = sessionOptional.orElseThrow();
                     Artifact artifact = artifactResult.getArtifact();
                     boolean resolved = artifactResult.isResolved();

--- a/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
@@ -45,12 +46,12 @@ import org.slf4j.LoggerFactory;
 public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final RepositorySystem repositorySystem;
-    private final SessionFactory sessionFactory;
+    private final Provider<SessionFactory> sessionFactoryProvider;
 
     @Inject
-    public MimirLifecycleParticipant(RepositorySystem repositorySystem, SessionFactory sessionFactory) {
+    public MimirLifecycleParticipant(RepositorySystem repositorySystem, Provider<SessionFactory> sessionFactoryProvider) {
         this.repositorySystem = repositorySystem;
-        this.sessionFactory = sessionFactory;
+        this.sessionFactoryProvider = sessionFactoryProvider;
     }
 
     @Override
@@ -69,8 +70,10 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
                                 session.getProjectBuildingRequest().getRemoteRepositories());
                         mayCheckForUpdates(sessionConfig, repoSession, remoteRepositories);
                         mayResolveDaemonArtifact(sessionConfig, repoSession, remoteRepositories);
+                        return sessionFactoryProvider.get().createSession(sessionConfig);
+                    } else {
+                        return null;
                     }
-                    return sessionFactory.createSession(sessionConfig);
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }

--- a/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirRepositoryConnectorFactory.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirRepositoryConnectorFactory.java
@@ -52,8 +52,7 @@ public class MimirRepositoryConnectorFactory implements RepositoryConnectorFacto
             throws NoRepositoryConnectorException {
         String message = "Mimir is disabled";
         Optional<Session> sessionOptional = MimirUtils.mayGetSession(session);
-        if (sessionOptional.isPresent()
-                && sessionOptional.orElseThrow().config().enabled()) {
+        if (sessionOptional.isPresent()) {
             Session mimirSession = sessionOptional.orElseThrow();
             message = "Unsupported repository: " + repository;
             if (mimirSession.repositorySupported(repository)) {

--- a/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirTrustedChecksumsSource.java
+++ b/extension/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirTrustedChecksumsSource.java
@@ -37,8 +37,7 @@ public class MimirTrustedChecksumsSource implements TrustedChecksumsSource {
             List<ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
         if (artifactRepository instanceof RemoteRepository remoteRepository) {
             Optional<Session> sessionOptional = MimirUtils.mayGetSession(session);
-            if (sessionOptional.isPresent()
-                    && sessionOptional.orElseThrow().config().enabled()) {
+            if (sessionOptional.isPresent()) {
                 Session ms = sessionOptional.orElseThrow();
                 if (ms.repositorySupported(remoteRepository) && ms.artifactSupported(artifact)) {
                     try {


### PR DESCRIPTION
Just apply same trick as with Njord: instead of direct injection, inject provider that is in Sisu lazy be default.