### PR TITLE
Fix thread pools

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -76,4 +76,29 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>java21</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <release>21</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java21</compileSourceRoot>
+              </compileSourceRoots>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/Executors.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/Executors.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.mimir.shared.impl;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.LoggerFactory;
+
+/**
+ * In pre-21 we use plain old thread pool.
+ */
+public final class Executors {
+    private Executors() {}
+
+    private static final AtomicBoolean executorWarned = new AtomicBoolean(false);
+
+    public static ExecutorService executorService() {
+        // Mimir targets dev Workstations; they are usually multicore; on low-end systems see below for configuration
+        if (Runtime.getRuntime().availableProcessors() < 3) {
+            if (executorWarned.compareAndSet(false, true)) {
+                LoggerFactory.getLogger(Executors.class)
+                        .warn("Low-end hardware/VM; use `mimir.session.localNode=file` in mimir.properties instead");
+            }
+        }
+        // no need for more than 12; but recommended is to use Mimir in Java 21+
+        return java.util.concurrent.Executors.newFixedThreadPool(
+                Math.max(1, Math.min(12, Runtime.getRuntime().availableProcessors() - 1)));
+    }
+}

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/Utils.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/Utils.java
@@ -14,8 +14,6 @@ import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Predicate;
 
 public final class Utils {
@@ -188,10 +186,5 @@ public final class Utils {
         } else {
             return addr -> addr.getHostAddress().equals(name);
         }
-    }
-
-    public static ExecutorService executorService() {
-        // Java 21: return Executors.newVirtualThreadPerTaskExecutor();
-        return Executors.newFixedThreadPool(Math.max(1, Runtime.getRuntime().availableProcessors() - 1));
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/publisher/HttpServerPublisher.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/publisher/HttpServerPublisher.java
@@ -13,7 +13,7 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-import eu.maveniverse.maven.mimir.shared.impl.Utils;
+import eu.maveniverse.maven.mimir.shared.impl.Executors;
 import eu.maveniverse.maven.mimir.shared.node.SystemEntry;
 import eu.maveniverse.maven.mimir.shared.node.SystemNode;
 import eu.maveniverse.maven.shared.core.component.ComponentSupport;
@@ -35,7 +35,7 @@ public class HttpServerPublisher extends PublisherSupport {
         super(systemNode, publisherConfig);
         httpServer = HttpServer.create(new InetSocketAddress(publisherConfig.hostPort()), 0);
 
-        httpServer.setExecutor(Utils.executorService());
+        httpServer.setExecutor(Executors.executorService());
         httpServer.createContext("/txid", new TxHandler(this::publishedEntry));
         logger.info(
                 "HTTP publisher starting at {} -> {}:{}",

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/publisher/ServerSocketPublisher.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/publisher/ServerSocketPublisher.java
@@ -7,7 +7,7 @@
  */
 package eu.maveniverse.maven.mimir.shared.impl.publisher;
 
-import eu.maveniverse.maven.mimir.shared.impl.Utils;
+import eu.maveniverse.maven.mimir.shared.impl.Executors;
 import eu.maveniverse.maven.mimir.shared.node.SystemEntry;
 import eu.maveniverse.maven.mimir.shared.node.SystemNode;
 import java.io.IOException;
@@ -31,7 +31,7 @@ public class ServerSocketPublisher extends PublisherSupport {
 
         InetSocketAddress inetSocketAddress = new InetSocketAddress(publisherConfig.hostPort());
         this.serverSocket = new ServerSocket(inetSocketAddress.getPort(), 50, inetSocketAddress.getAddress());
-        this.executor = Utils.executorService();
+        this.executor = Executors.executorService();
 
         Thread serverThread = new Thread(() -> {
             try {

--- a/core/src/main/java21/eu/maveniverse/maven/mimir/shared/impl/Executors.java
+++ b/core/src/main/java21/eu/maveniverse/maven/mimir/shared/impl/Executors.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.mimir.shared.impl;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * In Java 21 we use virtual threads, as those are ideal for these pure IO workloads.
+ */
+public final class Executors {
+    private Executors() {}
+
+    public static ExecutorService executorService() {
+        return java.util.concurrent.Executors.newVirtualThreadPerTaskExecutor();
+    }
+}

--- a/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNode.java
+++ b/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNode.java
@@ -12,7 +12,7 @@ import static eu.maveniverse.maven.mimir.shared.impl.Utils.splitChecksums;
 import static eu.maveniverse.maven.mimir.shared.impl.Utils.splitMetadata;
 import static java.util.Objects.requireNonNull;
 
-import eu.maveniverse.maven.mimir.shared.impl.Utils;
+import eu.maveniverse.maven.mimir.shared.impl.Executors;
 import eu.maveniverse.maven.mimir.shared.impl.node.RemoteNodeSupport;
 import eu.maveniverse.maven.mimir.shared.impl.publisher.PublisherRemoteEntry;
 import eu.maveniverse.maven.mimir.shared.node.Entry;
@@ -60,7 +60,7 @@ public class JGroupsNode extends RemoteNodeSupport<PublisherRemoteEntry> impleme
         this.messageDispatcher.setReceiver(this);
         this.publisher = null;
         this.lastView = new AtomicReference<>(null);
-        this.executor = Utils.executorService();
+        this.executor = Executors.executorService();
 
         channel.connect(clusterName, null, 1500);
     }
@@ -76,7 +76,7 @@ public class JGroupsNode extends RemoteNodeSupport<PublisherRemoteEntry> impleme
         this.messageDispatcher.setReceiver(this);
         this.publisher = publisher;
         this.lastView = new AtomicReference<>(null);
-        this.executor = Utils.executorService();
+        this.executor = Executors.executorService();
 
         channel.connect(clusterName, null, 1500);
     }


### PR DESCRIPTION
Daemon submitted itself to pool, and then wanted to submit each incoming connection to pool as well, that with blocking pool w/ size 1 blocked.

Also, make it right if daemon runs on Java 21, use VTs as originally.

Fixes #111 