### PR TITLE
JGroupsNode: make it disabled by def

### DIFF
--- a/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNodeConfig.java
+++ b/node/jgroups/src/main/java/eu/maveniverse/maven/mimir/node/jgroups/JGroupsNodeConfig.java
@@ -27,7 +27,7 @@ public class JGroupsNodeConfig {
             }
         }
 
-        boolean enabled = true;
+        boolean enabled = false;
         boolean publisherEnabled = true;
         String publisherTransport = "socket";
         String jgroupsProps = "udp-new.xml";


### PR DESCRIPTION
It is very niche feature, not used by many, and is unwanted on CI. So make it disabled by default.