### PR TITLE
Make Daemon "tighter"

### DIFF
--- a/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
+++ b/daemon/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
@@ -300,8 +300,11 @@ public class Daemon extends CloseableConfigSupport<DaemonConfig> implements Clos
         } catch (Exception e) {
             logger.error("Error while accepting client connection", e);
         } finally {
-            Files.deleteIfExists(daemonConfig.socketPath());
-            DirectoryLocker.INSTANCE.unlockDirectory(config.daemonLockDir());
+            try {
+                Files.deleteIfExists(daemonConfig.socketPath());
+            } finally {
+                DirectoryLocker.INSTANCE.unlockDirectory(config.daemonLockDir());
+            }
             logger.info("Daemon stopped");
         }
     }


### PR DESCRIPTION
Changes:
* lock daemon directory as early as possible
* delete stale UDS socket as early as possible
* create new UDS socket as late as possible (due pre-seeding)
* make sure UDS socket is removed once daemon exits; this was not the case