### PR TITLE
Bug: Daemon must reuse system node as local node

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionFactoryImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionFactoryImpl.java
@@ -68,9 +68,11 @@ public final class SessionFactoryImpl extends ComponentSupport implements Sessio
             }
         }
 
-        LocalNode localNode = createLocalNode(config.localNode(), config)
-                .orElseThrow(
-                        () -> new IllegalStateException("Chosen local node " + config.localNode() + " not configured"));
+        LocalNode localNode = config.localNodeInstance().isPresent()
+                ? config.localNodeInstance().orElseThrow()
+                : createLocalNode(config.localNode(), config)
+                        .orElseThrow(() -> new IllegalStateException(
+                                "Chosen local node " + config.localNode() + " not configured"));
 
         if (!overlays.isEmpty()) {
             localNode = new OverlayingLocalNode(overlays, localNode);

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/impl/SessionImpl.java
@@ -18,7 +18,6 @@ import eu.maveniverse.maven.shared.core.component.CloseableConfigSupport;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -166,16 +165,8 @@ public final class SessionImpl extends CloseableConfigSupport<SessionConfig> imp
 
     @Override
     protected void doClose() throws IOException {
-        ArrayList<IOException> exceptions = new ArrayList<>();
-        try {
+        if (config.localNodeInstance().isEmpty()) {
             localNode.close();
-        } catch (IOException e) {
-            exceptions.add(e);
-        }
-        if (!exceptions.isEmpty()) {
-            IOException closeException = new IOException("Could not close session");
-            exceptions.forEach(closeException::addSuppressed);
-            throw closeException;
         }
         logger.info("Mimir session closed (RETRIEVED={} CACHED={})", stats.transferSuccess(), stats.storeSuccess());
     }

--- a/daemon-slim/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
+++ b/daemon-slim/src/main/java/eu/maveniverse/maven/mimir/daemon/Daemon.java
@@ -389,6 +389,7 @@ public class Daemon extends CloseableConfigSupport<DaemonConfig> implements Clos
                 userProperties.put("mimir.session.localNode", systemNode.name());
                 SessionConfig sc = sessionConfig.toBuilder()
                         .userProperties(userProperties)
+                        .localNodeInstance(systemNode)
                         .repositorySystemSession(session)
                         .build();
                 try (eu.maveniverse.maven.mimir.shared.Session mimirSession =

--- a/it/extension-its/src/it/cp-w-p/.mvn/extensions.xml
+++ b/it/extension-its/src/it/cp-w-p/.mvn/extensions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.mimir</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension-its/src/it/cp-w-p/README.md
+++ b/it/extension-its/src/it/cp-w-p/README.md
@@ -1,0 +1,11 @@
+# Cache Purge combined with Preseed
+
+Uses Mimir in two builds, but SLF4J API version differs between the two. Second build invokes
+cache purge.
+
+To make cache purge work, following is required:
+* configure daemon for `mimir.file.exclusiveAccess=true`
+* configure daemon for `mimir.file.cachePurge=ON_BEGIN`
+
+In "exclusive access" the file now "owns" the storage, it is guaranteed only one node is accessing it. And 
+cache purge when enabled, is applied. BOTH are needed, otherwise configuration failure is reported.

--- a/it/extension-its/src/it/cp-w-p/invoker.properties
+++ b/it/extension-its/src/it/cp-w-p/invoker.properties
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+# 1st: mimir empty && local repo empty
+invoker.goals.1 = -Dversion.slf4j=2.0.10 -V -e clean install -l first.log -Dmimir.daemon.autostop -Dmimir.basedir=mimir -Dmimir.daemon.passOnBasedir -Dmaven.repo.local=first -Dmaven.repo.local.tail=../../it-repo-tail
+# 2nd: mimir primed && local repo empty
+invoker.goals.2 = -Dversion.slf4j=2.0.11 -V -e clean install -l second.log -Dmimir.daemon.autostop -Dmimir.basedir=mimir -Dmimir.daemon.passOnBasedir -Dmaven.repo.local=second -Dmaven.repo.local.tail=../../it-repo-tail

--- a/it/extension-its/src/it/cp-w-p/mimir/daemon.properties
+++ b/it/extension-its/src/it/cp-w-p/mimir/daemon.properties
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2023-2024 Maveniverse Org.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-v20.html
+#
+
+mimir.jgroups.enabled=false
+mimir.file.exclusiveAccess=true
+mimir.file.cachePurge=ON_BEGIN
+# we must override these to a release version
+mimir.daemon.itselfArtifacts=eu.maveniverse.maven.mimir:extension3:0.10.0@central
+mimir.daemon.preSeedArtifacts=eu.maveniverse.maven.mimir:extension3:0.8.0@central;eu.maveniverse.maven.mimir:extension3:0.3.6@alt-central::https://repo.maven.apache.org/maven2

--- a/it/extension-its/src/it/cp-w-p/pom.xml
+++ b/it/extension-its/src/it/cp-w-p/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2023-2024 Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.mimir.it.cp-w-p</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0.0</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${version.slf4j}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension-its/src/it/cp-w-p/verify.groovy
+++ b/it/extension-its/src/it/cp-w-p/verify.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File( basedir, 'build.log' )
+assert buildLog.exists()
+String build = buildLog.text
+
+File firstLog = new File( basedir, 'first.log' )
+assert firstLog.exists() : build
+String first = firstLog.text
+
+File secondLog = new File( basedir, 'second.log' )
+assert secondLog.exists() : first
+String second = secondLog.text
+
+// Lets make strict assertion
+// Also, consider Maven 3 vs 4 diff: they resolve differently; do not assert counts
+
+// first run: both were empty: retrieved==0 cached!=0
+assert first.contains('[INFO] Mimir session closed')
+assert first.contains('RETRIEVED=0')
+assert first.contains('CACHED=') && !first.contains('CACHED=0')
+
+// second run: mimir is primed, local repo is empty: retrieved!=0 cached==0
+assert second.contains('[INFO] Mimir session closed')
+assert second.contains('RETRIEVED=') && !second.contains('RETRIEVED=0')
+assert second.contains('CACHED=4')
+
+// aftermath: we used slf4j-api 2.0.10 in first run, but is not present in cache, only 2.0.11
+assert !new File(basedir, 'mimir/local/central/org.slf4j/slf4j-api/2.0.10/slf4j-api-2.0.10.pom').exists()
+assert new File(basedir, 'mimir/local/central/org.slf4j/slf4j-api/2.0.11/slf4j-api-2.0.11.pom').exists()

--- a/it/node-daemon-its/src/test/java/eu/maveniverse/maven/mimir/it/node/daemon/DaemonNodeFactoryIT.java
+++ b/it/node-daemon-its/src/test/java/eu/maveniverse/maven/mimir/it/node/daemon/DaemonNodeFactoryIT.java
@@ -34,6 +34,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+/**
+ * TODO: this test leaves running daemon instances!
+ */
 public class DaemonNodeFactoryIT {
     /**
      * Locker implementation using {@link ReentrantReadWriteLock} as FS locking is JVM wide.
@@ -135,7 +138,9 @@ public class DaemonNodeFactoryIT {
         DaemonNodeFactory factory1 = new DaemonNodeFactory(locker);
 
         try {
-            Optional<DaemonNode> dno = factory1.createLocalNode(sessionConfig);
+            Optional<DaemonNode> dno = factory1.createLocalNode(sessionConfig.toBuilder()
+                    .setUserProperty("mimir.daemon.autostop", Boolean.TRUE.toString())
+                    .build());
             assertTrue(dno.isPresent());
             try (DaemonNode daemonNode = dno.orElseThrow()) {
                 System.out.println("Session:");


### PR DESCRIPTION
When Daemon pre-seeds, and creates MIMA/Resolver session, it must reuse and not re-create local node, as if local node is configured for exclusive access, it will fail (by attempting to re-create new instance also having exclusive access). This makes combining cache-purge with pre-seed (where this happens) impossible.

Hence, SessionConfig must have means to pass in live instance of localNode. Also, when this happens, the session must NOT attempt to close it, as the localNode is not managed by it (as it is daemon systemNode).

Added IT where Cache Purge happens combined with Pre-seed, as this was the combination that revealed the issue (as this is when Daemon creates MIMA/Resolver session).