### PR TITLE
Replace msgpack-java with Java standard serialization

### DIFF
--- a/daemon-protocol/pom.xml
+++ b/daemon-protocol/pom.xml
@@ -22,11 +22,6 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <dependencies>
-    <dependency>
-      <groupId>org.msgpack</groupId>
-      <artifactId>msgpack-core</artifactId>
-    </dependency>
-
     <!-- Immutables: compile-time only dependency -->
     <dependency>
       <groupId>org.immutables</groupId>

--- a/node/file/pom.xml
+++ b/node/file/pom.xml
@@ -33,11 +33,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.msgpack</groupId>
-      <artifactId>msgpack-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -283,12 +283,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.msgpack</groupId>
-        <artifactId>msgpack-core</artifactId>
-        <version>0.9.10</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.jgroups</groupId>
         <artifactId>jgroups</artifactId>
         <version>5.5.1.Final</version>


### PR DESCRIPTION
Fixes #200

## Summary

This PR replaces the msgpack-java library with Java's standard ObjectOutputStream/ObjectInputStream serialization to eliminate warnings about deprecated `sun.misc.Unsafe` methods that will be removed in future Java releases.

## Changes

- **Daemon Protocol (`Handle.java`)**: Replaced msgpack serialization with ObjectOutputStream/ObjectInputStream for request/response communication over Unix Domain Sockets
- **File Node Metadata (`FileNode.java`)**: Replaced msgpack serialization with ObjectOutputStream/ObjectInputStream for metadata storage
- **Dependencies**: Removed msgpack-core dependency from all pom.xml files

## Breaking Change

⚠️ This is a **breaking change** that requires rebuilding all Mimir caches, as the serialization format has changed from msgpack to Java standard serialization.

## Testing

- All existing tests pass (23 tests, 0 failures)
- Full build completed successfully: `./mvnw clean install`
- Verified daemon protocol serialization/deserialization works correctly
- Verified file node metadata storage works correctly

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author