### PR TITLE
Add transfer log feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,86 @@ Build requirements:
 * Java 21
 * Maven 3.9.9+
 
+## Transfer Log
+
+Mimir can log every artifact download to a file, giving you a full record of what was fetched during a
+build — including groupId, artifactId, version, classifier, extension, the repository it came from, the
+canonical artifact URL, and whether the file was served from cache or downloaded fresh.
+
+### Enabling
+
+Add `-Dmimir.transferLog.enabled=true` to your Maven invocation:
+
+```
+mvn verify -Dmimir.transferLog.enabled=true
+```
+
+Or set it permanently in `~/.mimir/session.properties`:
+
+```properties
+mimir.transferLog.enabled=true
+```
+
+### Output files
+
+By default a single file is written to `~/.mimir/mimir-transfer-log.csv`. This file **accumulates
+across builds** — each build appends to it. It persists until you delete it manually (log rotation is
+your responsibility if the file grows large).
+
+To also write a per-project log that gets wiped by `mvn clean`, configure a project-relative path:
+
+```properties
+mimir.transferLog.projectPath=target/mimir-transfer-log.csv
+```
+
+Both files are written simultaneously when both are configured.
+
+To override the global file location:
+
+```properties
+mimir.transferLog.path=/path/to/my-transfer-log.csv
+```
+
+### Format
+
+The default format is CSV with a header row:
+
+```
+timestamp,groupId,artifactId,version,classifier,extension,repositoryId,repositoryUrl,artifactUrl,status
+2026-04-30T10:15:03Z,com.google.guava,guava,33.6.0-jre,,jar,central,https://repo.maven.apache.org/maven2,https://repo.maven.apache.org/maven2/com/google/guava/guava/33.6.0-jre/guava-33.6.0-jre.jar,cache
+2026-04-30T10:15:03Z,com.google.guava,guava,33.6.0-jre,,pom,central,https://repo.maven.apache.org/maven2,https://repo.maven.apache.org/maven2/com/google/guava/guava/33.6.0-jre/guava-33.6.0-jre.pom,remote
+```
+
+To use JSON Lines instead:
+
+```properties
+mimir.transferLog.format=jsonl
+```
+
+```json
+{"timestamp":"2026-04-30T10:15:03Z","groupId":"com.google.guava","artifactId":"guava","version":"33.6.0-jre","classifier":"","extension":"jar","repositoryId":"central","repositoryUrl":"https://repo.maven.apache.org/maven2","artifactUrl":"https://repo.maven.apache.org/maven2/com/google/guava/guava/33.6.0-jre/guava-33.6.0-jre.jar","status":"cache"}
+```
+
+### Status values
+
+| Value | Meaning |
+|---|---|
+| `cache` | Served from the Mimir local cache — no network request was made |
+| `remote` | Downloaded from the remote repository and stored in cache |
+| `failed` | Download was attempted but failed (network error, 404, etc.) |
+
+All artifact types are logged: `.jar`, `.pom`, `.asc` signatures, `.war`, `.aar`, etc. Internal
+existence-check probes are not logged.
+
+### Configuration reference
+
+| Property | Default | Description |
+|---|---|---|
+| `mimir.transferLog.enabled` | `false` | Enable transfer logging |
+| `mimir.transferLog.path` | `~/.mimir/mimir-transfer-log.csv` | Path to the global log file |
+| `mimir.transferLog.projectPath` | *(unset)* | Optional second log file (relative to execution root) |
+| `mimir.transferLog.format` | `csv` | Output format: `csv` or `jsonl` |
+
 ## High level design
 
 TBD

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/MimirUtils.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/MimirUtils.java
@@ -49,4 +49,16 @@ public final class MimirUtils {
         requireNonNull(repositorySystemSession, "repositorySystemSession");
         return Optional.ofNullable((Session) repositorySystemSession.getData().get(Session.class.getName()));
     }
+
+    public static void setTransferLog(RepositorySystemSession repositorySystemSession, TransferLog log) {
+        requireNonNull(repositorySystemSession, "repositorySystemSession");
+        requireNonNull(log, "log");
+        repositorySystemSession.getData().set(TransferLog.class.getName(), log);
+    }
+
+    public static Optional<TransferLog> mayGetTransferLog(RepositorySystemSession repositorySystemSession) {
+        requireNonNull(repositorySystemSession, "repositorySystemSession");
+        return Optional.ofNullable(
+                (TransferLog) repositorySystemSession.getData().get(TransferLog.class.getName()));
+    }
 }

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/SessionConfig.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/SessionConfig.java
@@ -152,6 +152,45 @@ public interface SessionConfig {
      */
     Set<String> mirrors();
 
+    // transfer log config
+
+    /**
+     * Enables artifact transfer logging. Defaults to {@code false}.
+     * <p>
+     * Configuration key {@code mimir.transferLog.enabled}
+     */
+    String CONF_TRANSFER_LOG_ENABLED = CONF_PREFIX + "transferLog.enabled";
+
+    /**
+     * Path to the global transfer log file. Defaults to {@code mimir-transfer-log.csv} under {@link #basedir()}.
+     * <p>
+     * Configuration key {@code mimir.transferLog.path}
+     */
+    String CONF_TRANSFER_LOG_PATH = CONF_PREFIX + "transferLog.path";
+
+    /**
+     * Optional path to a per-project transfer log file. Relative paths are resolved against the Maven execution
+     * root directory. When unset, no second log file is written.
+     * <p>
+     * Configuration key {@code mimir.transferLog.projectPath}
+     */
+    String CONF_TRANSFER_LOG_PROJECT_PATH = CONF_PREFIX + "transferLog.projectPath";
+
+    /**
+     * Transfer log output format. Accepted values: {@code csv} (default) or {@code jsonl}.
+     * <p>
+     * Configuration key {@code mimir.transferLog.format}
+     */
+    String CONF_TRANSFER_LOG_FORMAT = CONF_PREFIX + "transferLog.format";
+
+    boolean transferLogEnabled();
+
+    Path transferLogPath();
+
+    Optional<String> transferLogProjectPath();
+
+    String transferLogFormat();
+
     // components on/off
 
     boolean resolverConnectorEnabled();
@@ -358,6 +397,12 @@ public interface SessionConfig {
             private final boolean resolverResolverPostProcessorEnabled;
             private final boolean resolverTrustedChecksumsSourceEnabled;
 
+            // transfer log config (derived from effectiveProperties)
+            private final boolean transferLogEnabled;
+            private final Path transferLogPath;
+            private final String transferLogProjectPath;
+            private final String transferLogFormat;
+
             // session impl config (derived from that above)
             private final Set<String> overlayNodes;
             private final String localNode;
@@ -419,6 +464,18 @@ public interface SessionConfig {
                 this.resolverConnectorEnabled = resolverConnectorEnabled;
                 this.resolverResolverPostProcessorEnabled = resolverResolverPostProcessorEnabled;
                 this.resolverTrustedChecksumsSourceEnabled = resolverTrustedChecksumsSourceEnabled;
+
+                // transfer log (derived from those above)
+
+                this.transferLogEnabled = Boolean.parseBoolean(
+                        effectiveProperties.getOrDefault(CONF_TRANSFER_LOG_ENABLED, Boolean.FALSE.toString()));
+                String tlPath = effectiveProperties.get(CONF_TRANSFER_LOG_PATH);
+                this.transferLogPath =
+                        tlPath != null ? this.basedir.resolve(tlPath) : this.basedir.resolve("mimir-transfer-log.csv");
+                this.transferLogProjectPath = effectiveProperties.get(CONF_TRANSFER_LOG_PROJECT_PATH);
+                this.transferLogFormat = effectiveProperties
+                        .getOrDefault(CONF_TRANSFER_LOG_FORMAT, "csv")
+                        .toLowerCase();
 
                 // session impl (derived from those above)
 
@@ -529,6 +586,26 @@ public interface SessionConfig {
             @Override
             public Set<String> mirrors() {
                 return mirrors;
+            }
+
+            @Override
+            public boolean transferLogEnabled() {
+                return transferLogEnabled;
+            }
+
+            @Override
+            public Path transferLogPath() {
+                return transferLogPath;
+            }
+
+            @Override
+            public Optional<String> transferLogProjectPath() {
+                return Optional.ofNullable(transferLogProjectPath);
+            }
+
+            @Override
+            public String transferLogFormat() {
+                return transferLogFormat;
             }
 
             @Override

--- a/core/src/main/java/eu/maveniverse/maven/mimir/shared/TransferLog.java
+++ b/core/src/main/java/eu/maveniverse/maven/mimir/shared/TransferLog.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2023-2024 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.mimir.shared;
+
+import static java.util.Objects.requireNonNull;
+
+import eu.maveniverse.maven.mimir.shared.impl.naming.Artifacts;
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.RemoteRepository;
+
+/**
+ * Appends one record per artifact download to one or two log files (global and optional per-project).
+ * Thread-safe. Supported formats: {@code csv} and {@code jsonl}.
+ */
+public final class TransferLog implements Closeable {
+    public static final String STATUS_CACHE = "cache";
+    public static final String STATUS_REMOTE = "remote";
+    public static final String STATUS_FAILED = "failed";
+
+    private static final String CSV_HEADER =
+            "timestamp,groupId,artifactId,version,classifier,extension,repositoryId,repositoryUrl,artifactUrl,status";
+
+    private final String format;
+    private final List<BufferedWriter> writers;
+
+    public TransferLog(Path globalPath, /* @Nullable */ Path projectPath, String format) throws IOException {
+        requireNonNull(globalPath, "globalPath");
+        requireNonNull(format, "format");
+        this.format = format;
+        this.writers = new ArrayList<>(2);
+        writers.add(openWriter(globalPath));
+        if (projectPath != null) {
+            writers.add(openWriter(projectPath));
+        }
+    }
+
+    private BufferedWriter openWriter(Path path) throws IOException {
+        Files.createDirectories(path.getParent());
+        boolean isNew = !Files.exists(path) || Files.size(path) == 0;
+        BufferedWriter writer = Files.newBufferedWriter(path, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+        if ("csv".equals(format) && isNew) {
+            writer.write(CSV_HEADER);
+            writer.newLine();
+            writer.flush();
+        }
+        return writer;
+    }
+
+    public synchronized void record(RemoteRepository repo, Artifact artifact, String status) throws IOException {
+        requireNonNull(repo, "repo");
+        requireNonNull(artifact, "artifact");
+        requireNonNull(status, "status");
+
+        String timestamp = Instant.now().toString();
+        String groupId = artifact.getGroupId();
+        String artifactId = artifact.getArtifactId();
+        String version = artifact.getVersion();
+        String classifier = artifact.getClassifier() != null ? artifact.getClassifier() : "";
+        String extension = artifact.getExtension() != null ? artifact.getExtension() : "";
+        String repoId = repo.getId();
+        String repoUrl = repo.getUrl();
+        String artifactUrl = repoUrl.endsWith("/")
+                ? repoUrl + Artifacts.artifactRepositoryPath(artifact)
+                : repoUrl + "/" + Artifacts.artifactRepositoryPath(artifact);
+
+        String line;
+        if ("jsonl".equals(format)) {
+            line = "{\"timestamp\":\""
+                    + escapeJson(timestamp)
+                    + "\",\"groupId\":\""
+                    + escapeJson(groupId)
+                    + "\",\"artifactId\":\""
+                    + escapeJson(artifactId)
+                    + "\",\"version\":\""
+                    + escapeJson(version)
+                    + "\",\"classifier\":\""
+                    + escapeJson(classifier)
+                    + "\",\"extension\":\""
+                    + escapeJson(extension)
+                    + "\",\"repositoryId\":\""
+                    + escapeJson(repoId)
+                    + "\",\"repositoryUrl\":\""
+                    + escapeJson(repoUrl)
+                    + "\",\"artifactUrl\":\""
+                    + escapeJson(artifactUrl)
+                    + "\",\"status\":\""
+                    + escapeJson(status)
+                    + "\"}";
+        } else {
+            line = csvField(timestamp)
+                    + ","
+                    + csvField(groupId)
+                    + ","
+                    + csvField(artifactId)
+                    + ","
+                    + csvField(version)
+                    + ","
+                    + csvField(classifier)
+                    + ","
+                    + csvField(extension)
+                    + ","
+                    + csvField(repoId)
+                    + ","
+                    + csvField(repoUrl)
+                    + ","
+                    + csvField(artifactUrl)
+                    + ","
+                    + csvField(status);
+        }
+
+        for (BufferedWriter writer : writers) {
+            writer.write(line);
+            writer.newLine();
+        }
+        for (BufferedWriter writer : writers) {
+            writer.flush();
+        }
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        IOException first = null;
+        for (BufferedWriter writer : writers) {
+            try {
+                writer.close();
+            } catch (IOException e) {
+                if (first == null) first = e;
+            }
+        }
+        if (first != null) throw first;
+    }
+
+    private static String csvField(String value) {
+        if (value == null || value.isEmpty()) return "";
+        if (value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    private static String escapeJson(String value) {
+        if (value == null || value.isEmpty()) return "";
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirLifecycleParticipant.java
@@ -11,10 +11,12 @@ import eu.maveniverse.maven.mimir.node.daemon.DaemonNodeConfig;
 import eu.maveniverse.maven.mimir.shared.MimirUtils;
 import eu.maveniverse.maven.mimir.shared.SessionConfig;
 import eu.maveniverse.maven.mimir.shared.SessionFactory;
+import eu.maveniverse.maven.mimir.shared.TransferLog;
 import eu.maveniverse.maven.shared.core.fs.FileUtils;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -87,6 +89,13 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
                     }
                 }
             });
+            MimirUtils.mayGetTransferLog(session.getRepositorySession()).ifPresent(log -> {
+                try {
+                    log.close();
+                } catch (IOException e) {
+                    logger.warn("Error closing Mimir transfer log; ignoring", e);
+                }
+            });
         } catch (Exception e) {
             throw new MavenExecutionException("Error closing Mimir session", e);
         }
@@ -110,6 +119,7 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
                     }
 
                     MimirUtils.lazyInit(session.getRepositorySession(), sessionFactory, sessionConfig);
+                    mayInitTransferLog(session, repoSession, sessionConfig);
                 } else {
                     logger.info("Mimir {} is disabled", sessionConfig.mimirVersion());
                 }
@@ -120,6 +130,28 @@ public class MimirLifecycleParticipant extends AbstractMavenLifecycleParticipant
                     throw new MavenExecutionException("Error enabling Mimir", e);
                 }
             }
+        }
+    }
+
+    private void mayInitTransferLog(
+            MavenSession session, RepositorySystemSession repoSession, SessionConfig sessionConfig) {
+        if (!sessionConfig.transferLogEnabled()) {
+            return;
+        }
+        try {
+            Path globalPath = sessionConfig.transferLogPath();
+            Path projectPath = sessionConfig
+                    .transferLogProjectPath()
+                    .map(p -> Path.of(session.getRequest().getBaseDirectory()).resolve(p))
+                    .orElse(null);
+            TransferLog log = new TransferLog(globalPath, projectPath, sessionConfig.transferLogFormat());
+            MimirUtils.setTransferLog(repoSession, log);
+            logger.info("Mimir transfer log: {}", globalPath);
+            if (projectPath != null) {
+                logger.info("Mimir transfer log (project): {}", projectPath);
+            }
+        } catch (IOException e) {
+            logger.warn("Failed to initialize Mimir transfer log; artifact logging will be skipped", e);
         }
     }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirRepositoryConnector.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirRepositoryConnector.java
@@ -11,11 +11,13 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.mimir.shared.Entry;
 import eu.maveniverse.maven.mimir.shared.Session;
+import eu.maveniverse.maven.mimir.shared.TransferLog;
 import eu.maveniverse.maven.shared.core.component.ComponentSupport;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,13 +48,15 @@ public class MimirRepositoryConnector extends ComponentSupport implements Reposi
     private final RepositoryConnector delegate;
     private final List<ChecksumAlgorithmFactory> resolverChecksumAlgorithmFactories;
     private final Map<String, ChecksumAlgorithmFactory> allChecksumAlgorithmFactoryMap;
+    private final TransferLog transferLog; // @Nullable
 
     public MimirRepositoryConnector(
             Session mimirSession,
             RemoteRepository remoteRepository,
             RepositoryConnector delegate,
             List<ChecksumAlgorithmFactory> resolverChecksumAlgorithmFactories,
-            Map<String, ChecksumAlgorithmFactory> allChecksumAlgorithmFactoryMap) {
+            Map<String, ChecksumAlgorithmFactory> allChecksumAlgorithmFactoryMap,
+            TransferLog transferLog) {
         this.mimirSession = requireNonNull(mimirSession, "mimirSession");
         this.remoteRepository = requireNonNull(remoteRepository, "remoteRepository");
         this.delegate = requireNonNull(delegate, "delegate");
@@ -60,6 +64,7 @@ public class MimirRepositoryConnector extends ComponentSupport implements Reposi
                 requireNonNull(resolverChecksumAlgorithmFactories, "resolverChecksumAlgorithmFactories");
         this.allChecksumAlgorithmFactoryMap =
                 requireNonNull(allChecksumAlgorithmFactoryMap, "allChecksumAlgorithmFactoryMap");
+        this.transferLog = transferLog;
     }
 
     @Override
@@ -69,6 +74,7 @@ public class MimirRepositoryConnector extends ComponentSupport implements Reposi
         // 1st round: provide whatever we have cached
         List<ArtifactDownload> ads = new ArrayList<>();
         HashMap<Artifact, PotentiallyCached> keys = new HashMap<>();
+        List<Map.Entry<Artifact, String>> toLog = transferLog != null ? new ArrayList<>() : null;
         if (artifactDownloads != null && !artifactDownloads.isEmpty()) {
             for (ArtifactDownload artifactDownload : artifactDownloads) {
                 if (artifactDownload.isExistenceCheck()
@@ -82,6 +88,10 @@ public class MimirRepositoryConnector extends ComponentSupport implements Reposi
                             logger.debug("Fetched {} from Mimir cache", artifactDownload.getArtifact());
                             Path artifactFile = artifactDownload.getFile().toPath();
                             ce.transferTo(artifactFile);
+                            if (toLog != null) {
+                                toLog.add(new AbstractMap.SimpleImmutableEntry<>(
+                                        artifactDownload.getArtifact(), TransferLog.STATUS_CACHE));
+                            }
                             String checksum = null;
                             for (ChecksumAlgorithmFactory checksumAlgorithmFactory :
                                     resolverChecksumAlgorithmFactories) {
@@ -155,6 +165,23 @@ public class MimirRepositoryConnector extends ComponentSupport implements Reposi
                         artifactDownload.setException(
                                 new ArtifactTransferException(artifactDownload.getArtifact(), remoteRepository, e));
                     }
+                }
+                if (toLog != null && !artifactDownload.isExistenceCheck()) {
+                    toLog.add(new AbstractMap.SimpleImmutableEntry<>(
+                            artifactDownload.getArtifact(),
+                            artifactDownload.getException() != null
+                                    ? TransferLog.STATUS_FAILED
+                                    : TransferLog.STATUS_REMOTE));
+                }
+            }
+        }
+
+        if (toLog != null) {
+            for (Map.Entry<Artifact, String> entry : toLog) {
+                try {
+                    transferLog.record(remoteRepository, entry.getKey(), entry.getValue());
+                } catch (IOException e) {
+                    logger.warn("Failed to write transfer log entry for {}", entry.getKey(), e);
                 }
             }
         }

--- a/extension3/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirRepositoryConnectorFactory.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/mimir/extension3/MimirRepositoryConnectorFactory.java
@@ -11,6 +11,7 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.mimir.shared.MimirUtils;
 import eu.maveniverse.maven.mimir.shared.Session;
+import eu.maveniverse.maven.mimir.shared.TransferLog;
 import eu.maveniverse.maven.shared.core.component.ComponentSupport;
 import java.util.List;
 import java.util.Map;
@@ -67,13 +68,15 @@ public class MimirRepositoryConnectorFactory extends ComponentSupport implements
                                 "aether.checksums.algorithms",
                                 "aether.layout.maven2.checksumAlgorithms" + repository.getId(),
                                 "aether.layout.maven2.checksumAlgorithms")));
+                TransferLog transferLog = MimirUtils.mayGetTransferLog(session).orElse(null);
                 return new MimirRepositoryConnector(
                         ms,
                         repository,
                         repositoryConnector,
                         checksumsAlgorithms,
                         checksumAlgorithmFactorySelector.getChecksumAlgorithmFactories().stream()
-                                .collect(Collectors.toMap(ChecksumAlgorithmFactory::getName, f -> f)));
+                                .collect(Collectors.toMap(ChecksumAlgorithmFactory::getName, f -> f)),
+                        transferLog);
             }
         }
         throw new NoRepositoryConnectorException(repository, message);


### PR DESCRIPTION
Just a quickly slapped together hack for now, it seems to work at least.

My main issue is that I have a chicken and egg situation. I want to run this extension and mode for a completely empty repo and gather everything needed for a project to build, but I cant have a completely empty repo because I have to build this first.

Also .. I have another tool in the works that uses a different approach to solve the same issue - see https://github.com/simpligility/maven-build-requirements

cc @adambkaplan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Transfer Log functionality to record artifact transfers in CSV or JSON Lines format
  * Supports configurable global and per-project logging with transfer status tracking (cache, remote, failed)
  * Configurable via system properties or configuration file with new documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maveniverse/mimir/pull/262)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->